### PR TITLE
Add macOS build support and update repo references

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,7 +31,7 @@ jobs:
           cp "$(which ffprobe)" bin/ffprobe
 
           # Download standalone yt-dlp binary (not the Homebrew Python wrapper)
-          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o bin/yt-dlp
+          curl -fL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o bin/yt-dlp
           chmod +x bin/yt-dlp
 
       - name: Convert icon to icns
@@ -54,7 +54,7 @@ jobs:
           pyinstaller \
             --name "HARMONI" \
             --windowed \
-            --onefile \
+            --onedir \
             --icon HARMONI.icns \
             --add-data "gui/resources/icons:gui/resources/icons" \
             --add-binary "bin/ffmpeg:bin" \

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -65,13 +65,6 @@ jobs:
             --strip \
             gui_main.py
 
-      - name: Verify bundled binaries
-        run: |
-          echo "=== App bundle structure ==="
-          find dist/HARMONI.app -name "yt-dlp" -o -name "ffmpeg" -o -name "ffprobe" 2>/dev/null || true
-          echo "=== bin/ contents ==="
-          ls -la dist/HARMONI.app/Contents/_internal/bin/ 2>/dev/null || ls -la dist/HARMONI.app/Contents/MacOS/bin/ 2>/dev/null || echo "bin/ not found in expected locations"
-
       - name: Detect architecture
         id: arch
         run: echo "arch=$(uname -m)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,99 @@
+name: Build macOS
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install FFmpeg and yt-dlp binaries
+        run: |
+          brew install ffmpeg yt-dlp
+          mkdir -p bin
+          cp "$(which ffmpeg)" bin/ffmpeg
+          cp "$(which ffprobe)" bin/ffprobe
+          cp "$(which yt-dlp)" bin/yt-dlp
+
+      - name: Convert icon to icns
+        run: |
+          mkdir -p icon.iconset
+          sips -z 16 16     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_16x16.png
+          sips -z 32 32     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_16x16@2x.png
+          sips -z 32 32     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_32x32.png
+          sips -z 64 64     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_32x32@2x.png
+          sips -z 128 128   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_128x128.png
+          sips -z 256 256   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_128x128@2x.png
+          sips -z 256 256   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_256x256.png
+          sips -z 512 512   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_256x256@2x.png
+          sips -z 512 512   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_512x512.png
+          sips -z 1024 1024 gui/resources/icons/app/app_icon.png --out icon.iconset/icon_512x512@2x.png
+          iconutil -c icns icon.iconset -o HARMONI.icns
+
+      - name: Build with PyInstaller
+        run: |
+          pyinstaller \
+            --name "HARMONI" \
+            --windowed \
+            --onefile \
+            --icon HARMONI.icns \
+            --add-data "gui/resources/icons:gui/resources/icons" \
+            --add-binary "bin/ffmpeg:bin" \
+            --add-binary "bin/ffprobe:bin" \
+            --add-binary "bin/yt-dlp:bin" \
+            --add-data "config.json.example:." \
+            --add-data "data:data" \
+            --strip \
+            gui_main.py
+
+      - name: Detect architecture
+        id: arch
+        run: echo "arch=$(uname -m)" >> "$GITHUB_OUTPUT"
+
+      - name: Create DMG
+        run: |
+          mkdir -p dmg_contents
+          if [ -d "dist/HARMONI.app" ]; then
+            cp -r dist/HARMONI.app dmg_contents/
+          else
+            cp -r dist/HARMONI dmg_contents/
+          fi
+          ln -s /Applications dmg_contents/Applications
+          hdiutil create -volname "HARMONI" -srcfolder dmg_contents -ov -format UDZO "HARMONI-macos-${{ steps.arch.outputs.arch }}.dmg"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: HARMONI-macos-${{ steps.arch.outputs.arch }}
+          path: HARMONI-macos-${{ steps.arch.outputs.arch }}.dmg
+
+  release:
+    needs: build-macos
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: HARMONI-macos-*/HARMONI-macos-*.dmg
+          draft: true

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,11 +25,14 @@ jobs:
 
       - name: Install FFmpeg and yt-dlp binaries
         run: |
-          brew install ffmpeg yt-dlp
+          brew install ffmpeg
           mkdir -p bin
           cp "$(which ffmpeg)" bin/ffmpeg
           cp "$(which ffprobe)" bin/ffprobe
-          cp "$(which yt-dlp)" bin/yt-dlp
+
+          # Download standalone yt-dlp binary (not the Homebrew Python wrapper)
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o bin/yt-dlp
+          chmod +x bin/yt-dlp
 
       - name: Convert icon to icns
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -65,6 +65,13 @@ jobs:
             --strip \
             gui_main.py
 
+      - name: Verify bundled binaries
+        run: |
+          echo "=== App bundle structure ==="
+          find dist/HARMONI.app -name "yt-dlp" -o -name "ffmpeg" -o -name "ffprobe" 2>/dev/null || true
+          echo "=== bin/ contents ==="
+          ls -la dist/HARMONI.app/Contents/_internal/bin/ 2>/dev/null || ls -la dist/HARMONI.app/Contents/MacOS/bin/ 2>/dev/null || echo "bin/ not found in expected locations"
+
       - name: Detect architecture
         id: arch
         run: echo "arch=$(uname -m)" >> "$GITHUB_OUTPUT"

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -23,7 +23,7 @@ echo "=== Installing Python dependencies ==="
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 
-# Install ffmpeg and yt-dlp if not present
+# Install ffmpeg if not present
 if ! command -v brew &>/dev/null; then
     echo "Error: Homebrew not found. Install from https://brew.sh"
     exit 1
@@ -34,17 +34,16 @@ if ! command -v ffmpeg &>/dev/null; then
     brew install ffmpeg
 fi
 
-if ! command -v yt-dlp &>/dev/null; then
-    echo "=== Installing yt-dlp via Homebrew ==="
-    brew install yt-dlp
-fi
-
 # Copy binaries for bundling
 echo "=== Bundling binaries ==="
 mkdir -p bin
 cp "$(which ffmpeg)" bin/ffmpeg
 cp "$(which ffprobe)" bin/ffprobe
-cp "$(which yt-dlp)" bin/yt-dlp
+
+# Download standalone yt-dlp binary (Homebrew version is a Python wrapper that won't work bundled)
+echo "=== Downloading standalone yt-dlp ==="
+curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o bin/yt-dlp
+chmod +x bin/yt-dlp
 
 # Convert icon to icns
 echo "=== Converting icon ==="

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -42,7 +42,7 @@ cp "$(which ffprobe)" bin/ffprobe
 
 # Download standalone yt-dlp binary (Homebrew version is a Python wrapper that won't work bundled)
 echo "=== Downloading standalone yt-dlp ==="
-curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o bin/yt-dlp
+curl -fL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o bin/yt-dlp
 chmod +x bin/yt-dlp
 
 # Convert icon to icns
@@ -65,7 +65,7 @@ echo "=== Building with PyInstaller ==="
 pyinstaller \
     --name "HARMONI" \
     --windowed \
-    --onefile \
+    --onedir \
     --icon HARMONI.icns \
     --add-data "gui/resources/icons:gui/resources/icons" \
     --add-binary "bin/ffmpeg:bin" \
@@ -93,7 +93,7 @@ DMG_NAME="HARMONI-macos-${ARCH}.dmg"
 hdiutil create -volname "HARMONI" -srcfolder dmg_contents -ov -format UDZO "$DMG_NAME"
 
 # Cleanup build artifacts
-rm -rf build icon.iconset dmg_contents HARMONI.icns HARMONI.spec bin
+rm -rf build icon.iconset dmg_contents HARMONI.icns bin
 
 echo ""
 echo "=== Build complete ==="

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== HARMONI macOS Build ==="
+
+# Check we're on macOS
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "Error: This script must be run on macOS"
+    exit 1
+fi
+
+ARCH="$(uname -m)"
+echo "Architecture: $ARCH"
+
+# Check Python
+if ! command -v python3 &>/dev/null; then
+    echo "Error: python3 not found. Install Python 3.12+ first."
+    exit 1
+fi
+
+# Install Python dependencies
+echo "=== Installing Python dependencies ==="
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+
+# Install ffmpeg and yt-dlp if not present
+if ! command -v brew &>/dev/null; then
+    echo "Error: Homebrew not found. Install from https://brew.sh"
+    exit 1
+fi
+
+if ! command -v ffmpeg &>/dev/null; then
+    echo "=== Installing FFmpeg via Homebrew ==="
+    brew install ffmpeg
+fi
+
+if ! command -v yt-dlp &>/dev/null; then
+    echo "=== Installing yt-dlp via Homebrew ==="
+    brew install yt-dlp
+fi
+
+# Copy binaries for bundling
+echo "=== Bundling binaries ==="
+mkdir -p bin
+cp "$(which ffmpeg)" bin/ffmpeg
+cp "$(which ffprobe)" bin/ffprobe
+cp "$(which yt-dlp)" bin/yt-dlp
+
+# Convert icon to icns
+echo "=== Converting icon ==="
+mkdir -p icon.iconset
+sips -z 16 16     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_16x16.png
+sips -z 32 32     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_16x16@2x.png
+sips -z 32 32     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_32x32.png
+sips -z 64 64     gui/resources/icons/app/app_icon.png --out icon.iconset/icon_32x32@2x.png
+sips -z 128 128   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_128x128.png
+sips -z 256 256   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_128x128@2x.png
+sips -z 256 256   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_256x256.png
+sips -z 512 512   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_256x256@2x.png
+sips -z 512 512   gui/resources/icons/app/app_icon.png --out icon.iconset/icon_512x512.png
+sips -z 1024 1024 gui/resources/icons/app/app_icon.png --out icon.iconset/icon_512x512@2x.png
+iconutil -c icns icon.iconset -o HARMONI.icns
+
+# Build with PyInstaller
+echo "=== Building with PyInstaller ==="
+pyinstaller \
+    --name "HARMONI" \
+    --windowed \
+    --onefile \
+    --icon HARMONI.icns \
+    --add-data "gui/resources/icons:gui/resources/icons" \
+    --add-binary "bin/ffmpeg:bin" \
+    --add-binary "bin/ffprobe:bin" \
+    --add-binary "bin/yt-dlp:bin" \
+    --add-data "config.json.example:." \
+    --add-data "data:data" \
+    --strip \
+    gui_main.py
+
+# Create DMG
+echo "=== Creating DMG ==="
+rm -rf dmg_contents
+mkdir -p dmg_contents
+if [ -d "dist/HARMONI.app" ]; then
+    cp -r dist/HARMONI.app dmg_contents/
+else
+    cp -r dist/HARMONI dmg_contents/
+fi
+
+# Add Applications symlink so users can drag to install
+ln -s /Applications dmg_contents/Applications
+
+DMG_NAME="HARMONI-macos-${ARCH}.dmg"
+hdiutil create -volname "HARMONI" -srcfolder dmg_contents -ov -format UDZO "$DMG_NAME"
+
+# Cleanup build artifacts
+rm -rf build icon.iconset dmg_contents HARMONI.icns HARMONI.spec bin
+
+echo ""
+echo "=== Build complete ==="
+echo "Output: $DMG_NAME"
+echo ""
+echo "To install: open the DMG and drag HARMONI to Applications."
+echo "On first launch, right-click > Open to bypass Gatekeeper."

--- a/config.py
+++ b/config.py
@@ -33,6 +33,8 @@ DEFAULT_CONFIG = {
     "max_backups": 10,
     "profile": "light",
     "exportify_watch_folder": "data/exportify",
+    "ffmpeg_path": "",
+    "ytdlp_path": "",
 
     # Sync behavior
     "sync_write_tracks_json": True,
@@ -133,6 +135,8 @@ CONFIG_SCHEMA = {
     "max_backups": {"type": int, "required": False, "min": 0, "max": 100},
     "profile": {"type": str, "required": False, "choices": ["light", "advanced", "minimal"]},
     "exportify_watch_folder": {"type": str, "required": False},
+    "ffmpeg_path": {"type": str, "required": False},
+    "ytdlp_path": {"type": str, "required": False},
 
     "sync_write_tracks_json": {"type": bool, "required": False},
     "auto_sync_enabled": {"type": bool, "required": False},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.9"
 
 services:
-  spotify-yt-dlp-downloader:
+  harmoni:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: spotify-yt-dlp-downloader
+    container_name: harmoni
 
     # This is an interactive CLI app (questionary menus), so keep STDIN + TTY attached.
     stdin_open: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,6 @@ Future features and improvements planned for HARMONI.
 
 ## Links
 
-- [GitHub Repository](https://github.com/Ssenseii/spotify-yt-dlp-downloader)
-- [Releases](https://github.com/Ssenseii/spotify-yt-dlp-downloader/releases)
-- [Issues](https://github.com/Ssenseii/spotify-yt-dlp-downloader/issues)
+- [GitHub Repository](https://github.com/Ssenseii/harmoni)
+- [Releases](https://github.com/Ssenseii/harmoni/releases)
+- [Issues](https://github.com/Ssenseii/harmoni/issues)

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -16,7 +16,7 @@ Run HARMONI in Docker without installing Python or ffmpeg locally.
 docker compose build
 
 # Run the application
-docker compose run --rm --service-ports spotify-yt-dlp-downloader
+docker compose run --rm --service-ports harmoni
 ```
 
 > For older Docker versions, use `docker-compose` instead.
@@ -27,7 +27,7 @@ docker compose run --rm --service-ports spotify-yt-dlp-downloader
 
 ```bash
 # Build the image
-docker build -t spotify-yt-dlp-downloader .
+docker build -t harmoni .
 
 # Run the container
 docker run --rm -it \
@@ -36,7 +36,7 @@ docker run --rm -it \
   -v "$(pwd)/export:/app/export" \
   -v "$(pwd)/config.json:/app/config.json" \
   -e TERM=xterm-256color \
-  spotify-yt-dlp-downloader
+  harmoni
 ```
 
 ---
@@ -61,10 +61,10 @@ The following directories are mounted as volumes to persist data:
 docker compose build --no-cache
 
 # Run interactively
-docker compose run --rm spotify-yt-dlp-downloader
+docker compose run --rm harmoni
 
 # Open a shell in the container (debugging)
-docker compose run --rm --entrypoint /bin/sh spotify-yt-dlp-downloader
+docker compose run --rm --entrypoint /bin/sh harmoni
 ```
 
 ---

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -18,8 +18,8 @@ The easiest way to use HARMONI - no installation required.
 
 ### Download
 
-1. Go to [GitHub Releases](https://github.com/Ssenseii/spotify-yt-dlp-downloader/releases)
-2. Download `HARMONI.exe` (Windows) or `HARMONI` (Linux/macOS)
+1. Go to [GitHub Releases](https://github.com/Ssenseii/harmoni/releases)
+2. Download `HARMONI.exe` (Windows) or `HARMONI-macos-arm64.dmg` (macOS)
 3. Double-click to run
 
 ### First Run
@@ -88,8 +88,8 @@ This script:
 #### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/Ssenseii/spotify-yt-dlp-downloader.git
-cd spotify-yt-dlp-downloader
+git clone https://github.com/Ssenseii/harmoni.git
+cd harmoni
 ```
 
 #### 2. Create Virtual Environment
@@ -135,7 +135,7 @@ Run HARMONI in a container without installing Python.
 docker compose build
 
 # Run interactively
-docker compose run --rm --service-ports spotify-yt-dlp-downloader
+docker compose run --rm --service-ports harmoni
 ```
 
 ### Using Docker Directly
@@ -187,7 +187,7 @@ Or use the GUI:
 ### Upgrade HARMONI
 
 ```bash
-cd spotify-yt-dlp-downloader
+cd harmoni
 git pull
 pip install -r requirements.txt
 ```

--- a/docs/guides/standalone.md
+++ b/docs/guides/standalone.md
@@ -6,9 +6,10 @@ HARMONI is available as a standalone executable that requires no Python installa
 
 ### From GitHub Releases
 
-1. Go to the [Releases page](https://github.com/Ssenseii/spotify-yt-dlp-downloader/releases)
-2. Download the latest `HARMONI.exe` (Windows) or `HARMONI` (Linux/macOS)
-3. Run the executable - no installation required
+1. Go to the [Releases page](https://github.com/Ssenseii/harmoni/releases)
+2. Download the version for your platform:
+   - **Windows**: `HARMONI.exe`
+   - **macOS (Apple Silicon)**: `HARMONI-macos-arm64.dmg`
 
 ---
 
@@ -22,9 +23,38 @@ Double-click `HARMONI.exe` or run from command prompt:
 HARMONI.exe
 ```
 
-### Linux/macOS
+### macOS
+
+#### Installing from DMG
+
+1. Open `HARMONI-macos-arm64.dmg`
+2. Drag **HARMONI** into your **Applications** folder
+3. Eject the DMG
+
+#### macOS Security (Gatekeeper)
+
+Since HARMONI is not signed with an Apple Developer certificate, macOS will block it on first launch:
+
+> "HARMONI" can't be opened because Apple cannot check it for malicious software.
+
+**To allow it:**
+
+1. Open **System Settings > Privacy & Security**
+2. Scroll down — you'll see a message about HARMONI being blocked
+3. Click **"Open Anyway"**
+4. Confirm when prompted
+
+Alternatively, right-click (or Control-click) the app and select **Open** from the context menu. This bypasses Gatekeeper for that specific app.
+
+You only need to do this once. After that, HARMONI will open normally.
+
+#### Running from Terminal
 
 ```bash
+# If installed to Applications
+open /Applications/HARMONI.app
+
+# If running from another location
 chmod +x HARMONI  # Make executable (first time only)
 ./HARMONI
 ```
@@ -41,11 +71,9 @@ On first launch, HARMONI will:
 
 ### FFmpeg
 
-FFmpeg is required for audio conversion. The GUI will detect if FFmpeg is missing and offer to download it automatically.
+FFmpeg is bundled with the standalone releases. If for some reason it's missing:
 
-**Manual installation:**
-
-- **Windows**: Download from [ffmpeg.org](https://ffmpeg.org/download.html) and add to PATH
+- **Windows**: The GUI will detect and offer to download it automatically
 - **macOS**: `brew install ffmpeg`
 - **Linux**: `sudo apt install ffmpeg` (Debian/Ubuntu)
 
@@ -55,6 +83,8 @@ FFmpeg is required for audio conversion. The GUI will detect if FFmpeg is missin
 
 When running as a standalone executable, files are stored relative to the executable:
 
+### Windows
+
 ```
 HARMONI.exe
 ├── config.json          # Configuration (created on first run)
@@ -63,6 +93,20 @@ HARMONI.exe
 │   ├── tracks.json
 │   └── playlists.json
 └── music/               # Downloaded music output
+```
+
+### macOS
+
+When installed to Applications, HARMONI stores its data in your home directory:
+
+```
+~/Library/Application Support/HARMONI/
+├── config.json
+├── data/
+│   ├── exportify/
+│   ├── tracks.json
+│   └── playlists.json
+└── music/
 ```
 
 ---
@@ -90,7 +134,7 @@ See [Configuration Reference](configuration.md) for all options.
 
 The executable is fully portable:
 
-1. Copy `HARMONI.exe` and `config.json` to any folder
+1. Copy the executable and `config.json` to any folder
 2. Create `data/exportify/` subfolder for CSV imports
 3. Run from anywhere
 
@@ -100,26 +144,36 @@ Music will download to the `music/` folder relative to the executable.
 
 ## Building from Source
 
-To build your own executable:
-
-### Prerequisites
+### Windows
 
 ```bash
-pip install pyinstaller
 pip install -r requirements.txt
-```
-
-### Build Command
-
-```bash
 pyinstaller HARMONI.spec
 ```
 
 The executable will be created in the `dist/` folder.
 
+### macOS
+
+Use the build script (requires Python 3.12+ and Homebrew):
+
+```bash
+chmod +x build-macos.sh
+./build-macos.sh
+```
+
+This will:
+- Install Python dependencies
+- Install and bundle ffmpeg via Homebrew
+- Convert the app icon to `.icns`
+- Build with PyInstaller
+- Create a `.dmg` file
+
+Output: `HARMONI-macos-<arch>.dmg`
+
 ### Build Options
 
-The `HARMONI.spec` file configures:
+The `HARMONI.spec` file (Windows) configures:
 
 - **Entry point**: `gui_main.py` (GUI version)
 - **Bundled files**: `config.json.example`, icon resources
@@ -147,7 +201,25 @@ Windows SmartScreen may block unsigned executables:
 
 This warning appears because the executable is not code-signed.
 
-### Missing DLL errors
+### macOS: "HARMONI is damaged and can't be opened"
+
+This can happen if the quarantine attribute is set. Remove it:
+
+```bash
+xattr -cr /Applications/HARMONI.app
+```
+
+Then try opening again.
+
+### macOS: App won't open at all
+
+Try launching from Terminal to see error output:
+
+```bash
+/Applications/HARMONI.app/Contents/MacOS/HARMONI
+```
+
+### Missing DLL errors (Windows)
 
 Ensure you have the [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) installed.
 
@@ -162,10 +234,7 @@ The GUI will show FFmpeg status in Settings:
 ### Application crashes on startup
 
 1. Delete `config.json` to reset to defaults
-2. Run from command prompt to see error messages:
-   ```cmd
-   HARMONI.exe
-   ```
+2. Run from command prompt/terminal to see error messages
 
 ### Antivirus false positives
 
@@ -194,8 +263,8 @@ The standalone executable has some limitations compared to the Python version:
 
 To update the standalone version:
 
-1. Download the latest release from GitHub
-2. Replace the old executable
+1. Download the latest release from [GitHub](https://github.com/Ssenseii/harmoni/releases)
+2. Replace the old executable (or drag the new `.app` to Applications on macOS)
 3. Your `config.json` and data files are preserved
 
 ---

--- a/gui/styles.py
+++ b/gui/styles.py
@@ -433,7 +433,7 @@ QGroupBox {{
     background-color: {COLORS["background_card"]};
     border: 1px solid {COLORS["border"]};
     border-radius: 12px;
-    margin-top: 8px;
+    margin-top: 14px;
     padding: 20px;
     padding-top: 36px;
     font-weight: 600;
@@ -441,9 +441,10 @@ QGroupBox {{
 
 QGroupBox::title {{
     subcontrol-origin: margin;
-    left: 16px;
-    top: 8px;
-    padding: 0 8px;
+    subcontrol-position: top left;
+    left: 20px;
+    top: 10px;
+    padding: 0 6px;
     color: {COLORS["text_secondary"]};
     font-size: 12px;
     font-weight: 600;

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -400,12 +400,10 @@ class SettingsView(QWidget):
 
     def _check_ytdlp_updates(self):
         """Start yt-dlp update check and installation."""
-        from gui.workers.ytdlp_updater import YtdlpUpdaterWorker
-
-        # Confirm update
         update_info = check_ytdlp_updates()
         current_version = update_info.get("current_version") if update_info else None
         has_update = update_info.get("update_available", False) if update_info else False
+        use_standalone = not current_version
 
         if current_version and has_update:
             latest_version = update_info.get("latest_version")
@@ -417,7 +415,7 @@ class SettingsView(QWidget):
         elif not current_version:
             message = (
                 "yt-dlp is not installed. Install it now?\n\n"
-                "This will download and install yt-dlp via pip.\n\n"
+                "This will download the standalone yt-dlp binary.\n\n"
                 "Continue?"
             )
         else:
@@ -437,17 +435,20 @@ class SettingsView(QWidget):
         if reply != QMessageBox.Yes:
             return
 
-        # Disable buttons during update
         self.ytdlp_update_btn.setEnabled(False)
         self.ytdlp_refresh_btn.setEnabled(False)
 
-        # Show progress
         self.ytdlp_progress.setVisible(True)
         self.ytdlp_progress_label.setVisible(True)
         self.ytdlp_progress.setValue(0)
 
-        # Create and start worker
-        self.ytdlp_worker = YtdlpUpdaterWorker()
+        if use_standalone:
+            from gui.workers.ytdlp_installer import YtdlpInstallerWorker
+            self.ytdlp_worker = YtdlpInstallerWorker()
+        else:
+            from gui.workers.ytdlp_updater import YtdlpUpdaterWorker
+            self.ytdlp_worker = YtdlpUpdaterWorker()
+
         self.ytdlp_worker.progress.connect(self._on_ytdlp_progress)
         self.ytdlp_worker.finished.connect(self._on_ytdlp_finished)
         self.ytdlp_worker.start()

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -463,19 +463,13 @@ class SettingsView(QWidget):
 
     def _check_ytdlp_updates(self):
         """Start yt-dlp update check and installation."""
-        update_info = check_ytdlp_updates()
-        current_version = update_info.get("current_version") if update_info else None
-        has_update = update_info.get("update_available", False) if update_info else False
-        use_standalone = not current_version
+        import shutil
 
-        if current_version and has_update:
-            latest_version = update_info.get("latest_version")
-            message = (
-                f"Update yt-dlp from {current_version} to {latest_version}?\n\n"
-                "This will download and install the latest version.\n\n"
-                "Continue?"
-            )
-        elif not current_version:
+        # Fast local check only — no network call
+        ytdlp_bin = self.config.get("ytdlp_path", "") or shutil.which("yt-dlp")
+        use_standalone = not (ytdlp_bin and os.path.isfile(ytdlp_bin))
+
+        if use_standalone:
             message = (
                 "yt-dlp is not installed. Install it now?\n\n"
                 "This will download the standalone yt-dlp binary.\n\n"
@@ -483,8 +477,8 @@ class SettingsView(QWidget):
             )
         else:
             message = (
-                f"yt-dlp is already up to date ({current_version}).\n\n"
-                "Check for updates anyway?"
+                "Download and install the latest yt-dlp?\n\n"
+                "Continue?"
             )
 
         reply = QMessageBox.question(

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -165,44 +165,51 @@ class SettingsView(QWidget):
 
         # Output Settings Group
         output_group = QGroupBox("Output Settings")
-        output_layout = QFormLayout(output_group)
-        output_layout.setSpacing(12)
+        output_layout = QVBoxLayout(output_group)
+        output_layout.setSpacing(10)
 
-        # Output directory
-        output_dir_layout = QHBoxLayout()
+        output_dir_label = QLabel("Output directory")
+        output_dir_label.setObjectName("muted")
+        output_layout.addWidget(output_dir_label)
+        output_dir_row = QHBoxLayout()
         self.output_dir_input = QLineEdit()
         self.output_dir_input.setPlaceholderText("Select output directory...")
-        output_dir_layout.addWidget(self.output_dir_input)
+        output_dir_row.addWidget(self.output_dir_input, 1)
         browse_btn = QPushButton("Browse")
         browse_btn.setObjectName("secondary")
         browse_btn.setFixedWidth(70)
         browse_btn.clicked.connect(self._browse_output_dir)
-        output_dir_layout.addWidget(browse_btn)
-        output_layout.addRow("Output Directory:", output_dir_layout)
+        output_dir_row.addWidget(browse_btn)
+        output_layout.addLayout(output_dir_row)
 
-        # Audio format
+        format_label = QLabel("Audio format")
+        format_label.setObjectName("muted")
+        output_layout.addWidget(format_label)
         self.format_combo = QComboBox()
         self.format_combo.addItems(["mp3", "flac", "wav", "aac", "ogg", "m4a"])
-        output_layout.addRow("Audio Format:", self.format_combo)
+        output_layout.addWidget(self.format_combo)
 
         layout.addWidget(output_group)
 
         # Spotify Settings Group
         spotify_group = QGroupBox("Spotify Settings")
-        spotify_layout = QFormLayout(spotify_group)
-        spotify_layout.setSpacing(12)
+        spotify_layout = QVBoxLayout(spotify_group)
+        spotify_layout.setSpacing(10)
 
-        # Client ID
+        client_id_label = QLabel("Client ID")
+        client_id_label.setObjectName("muted")
+        spotify_layout.addWidget(client_id_label)
         self.client_id_input = QLineEdit()
         self.client_id_input.setPlaceholderText("Enter your Spotify Client ID")
-        spotify_layout.addRow("Client ID:", self.client_id_input)
+        spotify_layout.addWidget(self.client_id_input)
 
-        # Redirect URI (read-only)
+        redirect_label = QLabel("Redirect URI")
+        redirect_label.setObjectName("muted")
+        spotify_layout.addWidget(redirect_label)
         self.redirect_uri_input = QLineEdit()
         self.redirect_uri_input.setReadOnly(True)
-        spotify_layout.addRow("Redirect URI:", self.redirect_uri_input)
+        spotify_layout.addWidget(self.redirect_uri_input)
 
-        # Help text
         help_label = QLabel(
             "To get a Spotify Client ID:\n"
             "1. Go to developer.spotify.com/dashboard\n"
@@ -212,63 +219,68 @@ class SettingsView(QWidget):
         )
         help_label.setObjectName("subtitle")
         help_label.setWordWrap(True)
-        spotify_layout.addRow("", help_label)
+        spotify_layout.addWidget(help_label)
 
         layout.addWidget(spotify_group)
 
         # Download Settings Group
         download_group = QGroupBox("Download Settings")
-        download_layout = QFormLayout(download_group)
-        download_layout.setSpacing(12)
+        download_layout = QVBoxLayout(download_group)
+        download_layout.setSpacing(10)
 
-        # Sleep between downloads
+        sleep_label = QLabel("Sleep between downloads (seconds)")
+        sleep_label.setObjectName("muted")
+        download_layout.addWidget(sleep_label)
         self.sleep_input = QLineEdit()
         self.sleep_input.setPlaceholderText("5")
-        self.sleep_input.setFixedWidth(80)
-        download_layout.addRow("Sleep Between (sec):", self.sleep_input)
+        self.sleep_input.setMaximumWidth(200)
+        download_layout.addWidget(self.sleep_input)
 
-        # Retry attempts
+        retry_label = QLabel("Retry attempts")
+        retry_label.setObjectName("muted")
+        download_layout.addWidget(retry_label)
         self.retry_input = QLineEdit()
         self.retry_input.setPlaceholderText("3")
-        self.retry_input.setFixedWidth(80)
-        download_layout.addRow("Retry Attempts:", self.retry_input)
+        self.retry_input.setMaximumWidth(200)
+        download_layout.addWidget(self.retry_input)
 
         layout.addWidget(download_group)
 
         # Metadata Settings Group
         metadata_group = QGroupBox("Metadata Settings")
-        metadata_layout = QFormLayout(metadata_group)
-        metadata_layout.setSpacing(12)
+        metadata_layout = QVBoxLayout(metadata_group)
+        metadata_layout.setSpacing(10)
 
-        # Enable metadata
         self.metadata_check = QCheckBox("Enable metadata embedding")
-        metadata_layout.addRow("", self.metadata_check)
+        metadata_layout.addWidget(self.metadata_check)
 
-        # Metadata template
+        template_label = QLabel("Template")
+        template_label.setObjectName("muted")
+        metadata_layout.addWidget(template_label)
         self.template_combo = QComboBox()
         self.template_combo.addItems(["basic", "comprehensive", "dj-mix"])
-        metadata_layout.addRow("Template:", self.template_combo)
+        metadata_layout.addWidget(self.template_combo)
 
-        # MusicBrainz lookup
         self.musicbrainz_check = QCheckBox("Enable MusicBrainz lookup")
-        metadata_layout.addRow("", self.musicbrainz_check)
+        metadata_layout.addWidget(self.musicbrainz_check)
 
         layout.addWidget(metadata_group)
 
         # Backup Settings Group
         backup_group = QGroupBox("Backup Settings")
-        backup_layout = QFormLayout(backup_group)
-        backup_layout.setSpacing(12)
+        backup_layout = QVBoxLayout(backup_group)
+        backup_layout.setSpacing(10)
 
-        # Auto backup
         self.backup_check = QCheckBox("Enable automatic backups")
-        backup_layout.addRow("", self.backup_check)
+        backup_layout.addWidget(self.backup_check)
 
-        # Max backups
+        max_backups_label = QLabel("Max backups")
+        max_backups_label.setObjectName("muted")
+        backup_layout.addWidget(max_backups_label)
         self.max_backups_input = QLineEdit()
         self.max_backups_input.setPlaceholderText("10")
-        self.max_backups_input.setFixedWidth(80)
-        backup_layout.addRow("Max Backups:", self.max_backups_input)
+        self.max_backups_input.setMaximumWidth(200)
+        backup_layout.addWidget(self.max_backups_input)
 
         layout.addWidget(backup_group)
 

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -146,6 +146,46 @@ class SettingsView(QWidget):
 
         layout.addWidget(ytdlp_group)
 
+        # Binary Paths Group
+        paths_group = QGroupBox("Binary Paths")
+        paths_layout = QFormLayout(paths_group)
+        paths_layout.setSpacing(12)
+
+        # FFmpeg path
+        ffmpeg_path_layout = QHBoxLayout()
+        self.ffmpeg_path_input = QLineEdit()
+        self.ffmpeg_path_input.setPlaceholderText("Auto-detect (leave empty)")
+        ffmpeg_path_layout.addWidget(self.ffmpeg_path_input)
+        ffmpeg_browse_btn = QPushButton("Browse")
+        ffmpeg_browse_btn.setObjectName("secondary")
+        ffmpeg_browse_btn.setFixedWidth(70)
+        ffmpeg_browse_btn.clicked.connect(self._browse_ffmpeg_path)
+        ffmpeg_path_layout.addWidget(ffmpeg_browse_btn)
+        paths_layout.addRow("FFmpeg Path:", ffmpeg_path_layout)
+
+        # yt-dlp path
+        ytdlp_path_layout = QHBoxLayout()
+        self.ytdlp_path_input = QLineEdit()
+        self.ytdlp_path_input.setPlaceholderText("Auto-detect (leave empty)")
+        ytdlp_path_layout.addWidget(self.ytdlp_path_input)
+        ytdlp_browse_btn = QPushButton("Browse")
+        ytdlp_browse_btn.setObjectName("secondary")
+        ytdlp_browse_btn.setFixedWidth(70)
+        ytdlp_browse_btn.clicked.connect(self._browse_ytdlp_path)
+        ytdlp_path_layout.addWidget(ytdlp_browse_btn)
+        paths_layout.addRow("yt-dlp Path:", ytdlp_path_layout)
+
+        # Help text
+        paths_help = QLabel(
+            "Set custom paths if auto-detection fails. "
+            "Leave empty to use bundled or system binaries."
+        )
+        paths_help.setObjectName("subtitle")
+        paths_help.setWordWrap(True)
+        paths_layout.addRow("", paths_help)
+
+        layout.addWidget(paths_group)
+
         # Output Settings Group
         output_group = QGroupBox("Output Settings")
         output_layout = QFormLayout(output_group)
@@ -289,6 +329,8 @@ class SettingsView(QWidget):
         self.musicbrainz_check.setChecked(self.config.get("enable_musicbrainz_lookup", True))
         self.backup_check.setChecked(self.config.get("auto_backup", True))
         self.max_backups_input.setText(str(self.config.get("max_backups", 10)))
+        self.ffmpeg_path_input.setText(self.config.get("ffmpeg_path", ""))
+        self.ytdlp_path_input.setText(self.config.get("ytdlp_path", ""))
 
     def _check_ffmpeg_status(self):
         """Check FFmpeg installation status."""
@@ -479,6 +521,18 @@ class SettingsView(QWidget):
         # Clean up worker
         self.ytdlp_worker = None
 
+    def _browse_ffmpeg_path(self):
+        """Open file browser for FFmpeg binary."""
+        path, _ = QFileDialog.getOpenFileName(self, "Select FFmpeg Binary")
+        if path:
+            self.ffmpeg_path_input.setText(path)
+
+    def _browse_ytdlp_path(self):
+        """Open file browser for yt-dlp binary."""
+        path, _ = QFileDialog.getOpenFileName(self, "Select yt-dlp Binary")
+        if path:
+            self.ytdlp_path_input.setText(path)
+
     def _browse_output_dir(self):
         """Open folder browser for output directory."""
         current_dir = self.output_dir_input.text() or os.path.expanduser("~")
@@ -525,6 +579,8 @@ class SettingsView(QWidget):
             self.config["enable_musicbrainz_lookup"] = self.musicbrainz_check.isChecked()
             self.config["auto_backup"] = self.backup_check.isChecked()
             self.config["max_backups"] = int(self.max_backups_input.text() or 10)
+            self.config["ffmpeg_path"] = self.ffmpeg_path_input.text().strip()
+            self.config["ytdlp_path"] = self.ytdlp_path_input.text().strip()
 
             # Validate
             is_valid, errors = validate_config(self.config)

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Signal
 
 from config import save_config, validate_config, DEFAULT_CONFIG, load_config
+from gui.styles import COLORS
 from utils.ffmpeg import check_ffmpeg_available
 from tools.ytdlp_update_checker import check_ytdlp_updates
 
@@ -50,109 +51,49 @@ class SettingsView(QWidget):
         title.setObjectName("title")
         layout.addWidget(title)
 
-        # FFmpeg Status Group - placed at top for visibility
-        ffmpeg_group = QGroupBox("FFmpeg Status")
-        ffmpeg_layout = QVBoxLayout(ffmpeg_group)
-        ffmpeg_layout.setSpacing(10)
+        # Dependencies Group
+        deps_group = QGroupBox("Dependencies")
+        deps_layout = QVBoxLayout(deps_group)
+        deps_layout.setSpacing(14)
 
-        # Status row
+        # --- FFmpeg section ---
+        ffmpeg_header = QLabel("FFmpeg")
+        ffmpeg_header.setObjectName("section")
+        deps_layout.addWidget(ffmpeg_header)
+
+        ffmpeg_desc = QLabel("Required for audio conversion.")
+        ffmpeg_desc.setObjectName("muted")
+        deps_layout.addWidget(ffmpeg_desc)
+
         status_row = QHBoxLayout()
         self.ffmpeg_status_icon = QLabel("●")
         self.ffmpeg_status_icon.setFixedWidth(20)
         status_row.addWidget(self.ffmpeg_status_icon)
-
         self.ffmpeg_status_label = QLabel("Checking...")
         status_row.addWidget(self.ffmpeg_status_label, 1)
-
         self.ffmpeg_install_btn = QPushButton("Install FFmpeg")
         self.ffmpeg_install_btn.setObjectName("secondary")
         self.ffmpeg_install_btn.clicked.connect(self._install_ffmpeg)
         status_row.addWidget(self.ffmpeg_install_btn)
-
         self.ffmpeg_refresh_btn = QPushButton("Refresh")
         self.ffmpeg_refresh_btn.setObjectName("secondary")
         self.ffmpeg_refresh_btn.setFixedWidth(70)
         self.ffmpeg_refresh_btn.clicked.connect(self._check_ffmpeg_status)
         status_row.addWidget(self.ffmpeg_refresh_btn)
+        deps_layout.addLayout(status_row)
 
-        ffmpeg_layout.addLayout(status_row)
-
-        # Progress bar (hidden by default)
         self.ffmpeg_progress = QProgressBar()
         self.ffmpeg_progress.setVisible(False)
-        ffmpeg_layout.addWidget(self.ffmpeg_progress)
-
+        deps_layout.addWidget(self.ffmpeg_progress)
         self.ffmpeg_progress_label = QLabel("")
         self.ffmpeg_progress_label.setObjectName("subtitle")
         self.ffmpeg_progress_label.setVisible(False)
-        ffmpeg_layout.addWidget(self.ffmpeg_progress_label)
+        deps_layout.addWidget(self.ffmpeg_progress_label)
 
-        # Help text
-        ffmpeg_help = QLabel(
-            "FFmpeg is required for audio conversion. "
-            "Click 'Install FFmpeg' to automatically download and install it."
-        )
-        ffmpeg_help.setObjectName("subtitle")
-        ffmpeg_help.setWordWrap(True)
-        ffmpeg_layout.addWidget(ffmpeg_help)
-
-        layout.addWidget(ffmpeg_group)
-
-        # yt-dlp Status Group
-        ytdlp_group = QGroupBox("yt-dlp Status")
-        ytdlp_layout = QVBoxLayout(ytdlp_group)
-        ytdlp_layout.setSpacing(10)
-
-        # Status row
-        ytdlp_status_row = QHBoxLayout()
-        self.ytdlp_status_icon = QLabel("●")
-        self.ytdlp_status_icon.setFixedWidth(20)
-        ytdlp_status_row.addWidget(self.ytdlp_status_icon)
-
-        self.ytdlp_status_label = QLabel("Checking...")
-        ytdlp_status_row.addWidget(self.ytdlp_status_label, 1)
-
-        self.ytdlp_update_btn = QPushButton("Check for Updates")
-        self.ytdlp_update_btn.setObjectName("secondary")
-        self.ytdlp_update_btn.clicked.connect(self._check_ytdlp_updates)
-        ytdlp_status_row.addWidget(self.ytdlp_update_btn)
-
-        self.ytdlp_refresh_btn = QPushButton("Refresh")
-        self.ytdlp_refresh_btn.setObjectName("secondary")
-        self.ytdlp_refresh_btn.setFixedWidth(70)
-        self.ytdlp_refresh_btn.clicked.connect(self._check_ytdlp_status)
-        ytdlp_status_row.addWidget(self.ytdlp_refresh_btn)
-
-        ytdlp_layout.addLayout(ytdlp_status_row)
-
-        # Progress bar (hidden by default)
-        self.ytdlp_progress = QProgressBar()
-        self.ytdlp_progress.setVisible(False)
-        ytdlp_layout.addWidget(self.ytdlp_progress)
-
-        self.ytdlp_progress_label = QLabel("")
-        self.ytdlp_progress_label.setObjectName("subtitle")
-        self.ytdlp_progress_label.setVisible(False)
-        ytdlp_layout.addWidget(self.ytdlp_progress_label)
-
-        # Help text
-        ytdlp_help = QLabel(
-            "yt-dlp is required for downloading videos from various sources. "
-            "Click 'Check for Updates' to update to the latest version."
-        )
-        ytdlp_help.setObjectName("subtitle")
-        ytdlp_help.setWordWrap(True)
-        ytdlp_layout.addWidget(ytdlp_help)
-
-        layout.addWidget(ytdlp_group)
-
-        # Binary Paths Group
-        paths_group = QGroupBox("Binary Paths")
-        paths_layout = QVBoxLayout(paths_group)
-        paths_layout.setSpacing(10)
-
-        # FFmpeg path
-        paths_layout.addWidget(QLabel("FFmpeg"))
+        # FFmpeg custom path
+        ffmpeg_path_label = QLabel("Custom path")
+        ffmpeg_path_label.setObjectName("muted")
+        deps_layout.addWidget(ffmpeg_path_label)
         ffmpeg_path_row = QHBoxLayout()
         self.ffmpeg_path_input = QLineEdit()
         self.ffmpeg_path_input.setPlaceholderText("Auto-detect (leave empty)")
@@ -162,10 +103,53 @@ class SettingsView(QWidget):
         ffmpeg_browse_btn.setFixedWidth(70)
         ffmpeg_browse_btn.clicked.connect(self._browse_ffmpeg_path)
         ffmpeg_path_row.addWidget(ffmpeg_browse_btn)
-        paths_layout.addLayout(ffmpeg_path_row)
+        deps_layout.addLayout(ffmpeg_path_row)
 
-        # yt-dlp path
-        paths_layout.addWidget(QLabel("yt-dlp"))
+        # --- Separator ---
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet(f"color: {COLORS['border']};")
+        sep.setFixedHeight(1)
+        deps_layout.addWidget(sep)
+
+        # --- yt-dlp section ---
+        ytdlp_header = QLabel("yt-dlp")
+        ytdlp_header.setObjectName("section")
+        deps_layout.addWidget(ytdlp_header)
+
+        ytdlp_desc = QLabel("Required for downloading from YouTube and other sources.")
+        ytdlp_desc.setObjectName("muted")
+        deps_layout.addWidget(ytdlp_desc)
+
+        ytdlp_status_row = QHBoxLayout()
+        self.ytdlp_status_icon = QLabel("●")
+        self.ytdlp_status_icon.setFixedWidth(20)
+        ytdlp_status_row.addWidget(self.ytdlp_status_icon)
+        self.ytdlp_status_label = QLabel("Checking...")
+        ytdlp_status_row.addWidget(self.ytdlp_status_label, 1)
+        self.ytdlp_update_btn = QPushButton("Check for Updates")
+        self.ytdlp_update_btn.setObjectName("secondary")
+        self.ytdlp_update_btn.clicked.connect(self._check_ytdlp_updates)
+        ytdlp_status_row.addWidget(self.ytdlp_update_btn)
+        self.ytdlp_refresh_btn = QPushButton("Refresh")
+        self.ytdlp_refresh_btn.setObjectName("secondary")
+        self.ytdlp_refresh_btn.setFixedWidth(70)
+        self.ytdlp_refresh_btn.clicked.connect(self._check_ytdlp_status)
+        ytdlp_status_row.addWidget(self.ytdlp_refresh_btn)
+        deps_layout.addLayout(ytdlp_status_row)
+
+        self.ytdlp_progress = QProgressBar()
+        self.ytdlp_progress.setVisible(False)
+        deps_layout.addWidget(self.ytdlp_progress)
+        self.ytdlp_progress_label = QLabel("")
+        self.ytdlp_progress_label.setObjectName("subtitle")
+        self.ytdlp_progress_label.setVisible(False)
+        deps_layout.addWidget(self.ytdlp_progress_label)
+
+        # yt-dlp custom path
+        ytdlp_path_label = QLabel("Custom path")
+        ytdlp_path_label.setObjectName("muted")
+        deps_layout.addWidget(ytdlp_path_label)
         ytdlp_path_row = QHBoxLayout()
         self.ytdlp_path_input = QLineEdit()
         self.ytdlp_path_input.setPlaceholderText("Auto-detect (leave empty)")
@@ -175,16 +159,9 @@ class SettingsView(QWidget):
         ytdlp_browse_btn.setFixedWidth(70)
         ytdlp_browse_btn.clicked.connect(self._browse_ytdlp_path)
         ytdlp_path_row.addWidget(ytdlp_browse_btn)
-        paths_layout.addLayout(ytdlp_path_row)
+        deps_layout.addLayout(ytdlp_path_row)
 
-        paths_help = QLabel(
-            "Set custom paths if auto-detection fails. Leave empty to use bundled or system binaries."
-        )
-        paths_help.setObjectName("subtitle")
-        paths_help.setWordWrap(True)
-        paths_layout.addWidget(paths_help)
-
-        layout.addWidget(paths_group)
+        layout.addWidget(deps_group)
 
         # Output Settings Group
         output_group = QGroupBox("Output Settings")

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -412,12 +412,12 @@ class SettingsView(QWidget):
         import subprocess
 
         version = None
-        found = False
+        found_path = None
 
-        # Check custom path from config first (instant, no subprocess)
+        # Check custom path from config first
         custom_path = self.config.get("ytdlp_path", "")
         if custom_path and os.path.isfile(custom_path):
-            found = True
+            found_path = custom_path
             try:
                 result = subprocess.run(
                     [custom_path, "--version"],
@@ -431,7 +431,7 @@ class SettingsView(QWidget):
             # Check PATH
             ytdlp_bin = shutil.which("yt-dlp")
             if ytdlp_bin:
-                found = True
+                found_path = ytdlp_bin
                 try:
                     result = subprocess.run(
                         [ytdlp_bin, "--version"],
@@ -442,16 +442,16 @@ class SettingsView(QWidget):
                 except Exception:
                     pass
 
-        if found and version:
+        if found_path and version:
             self.ytdlp_status_icon.setStyleSheet("color: #4caf50; font-size: 14px;")
-            self.ytdlp_status_label.setText(f"Installed: {version}")
+            self.ytdlp_status_label.setText(f"Installed: {version} ({found_path})")
             self.ytdlp_status_label.setStyleSheet("color: #4caf50;")
             self.ytdlp_update_btn.setText("Check for Updates")
             self.ytdlp_update_btn.setEnabled(True)
-        elif found:
-            self.ytdlp_status_icon.setStyleSheet("color: #ff9800; font-size: 14px;")
-            self.ytdlp_status_label.setText("Found but could not get version")
-            self.ytdlp_status_label.setStyleSheet("color: #ff9800;")
+        elif found_path:
+            self.ytdlp_status_icon.setStyleSheet("color: #4caf50; font-size: 14px;")
+            self.ytdlp_status_label.setText(f"Installed: {found_path}")
+            self.ytdlp_status_label.setStyleSheet("color: #4caf50;")
             self.ytdlp_update_btn.setText("Check for Updates")
             self.ytdlp_update_btn.setEnabled(True)
         else:

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -148,41 +148,41 @@ class SettingsView(QWidget):
 
         # Binary Paths Group
         paths_group = QGroupBox("Binary Paths")
-        paths_layout = QFormLayout(paths_group)
-        paths_layout.setSpacing(12)
+        paths_layout = QVBoxLayout(paths_group)
+        paths_layout.setSpacing(10)
 
         # FFmpeg path
-        ffmpeg_path_layout = QHBoxLayout()
+        paths_layout.addWidget(QLabel("FFmpeg"))
+        ffmpeg_path_row = QHBoxLayout()
         self.ffmpeg_path_input = QLineEdit()
         self.ffmpeg_path_input.setPlaceholderText("Auto-detect (leave empty)")
-        ffmpeg_path_layout.addWidget(self.ffmpeg_path_input)
+        ffmpeg_path_row.addWidget(self.ffmpeg_path_input, 1)
         ffmpeg_browse_btn = QPushButton("Browse")
         ffmpeg_browse_btn.setObjectName("secondary")
         ffmpeg_browse_btn.setFixedWidth(70)
         ffmpeg_browse_btn.clicked.connect(self._browse_ffmpeg_path)
-        ffmpeg_path_layout.addWidget(ffmpeg_browse_btn)
-        paths_layout.addRow("FFmpeg Path:", ffmpeg_path_layout)
+        ffmpeg_path_row.addWidget(ffmpeg_browse_btn)
+        paths_layout.addLayout(ffmpeg_path_row)
 
         # yt-dlp path
-        ytdlp_path_layout = QHBoxLayout()
+        paths_layout.addWidget(QLabel("yt-dlp"))
+        ytdlp_path_row = QHBoxLayout()
         self.ytdlp_path_input = QLineEdit()
         self.ytdlp_path_input.setPlaceholderText("Auto-detect (leave empty)")
-        ytdlp_path_layout.addWidget(self.ytdlp_path_input)
+        ytdlp_path_row.addWidget(self.ytdlp_path_input, 1)
         ytdlp_browse_btn = QPushButton("Browse")
         ytdlp_browse_btn.setObjectName("secondary")
         ytdlp_browse_btn.setFixedWidth(70)
         ytdlp_browse_btn.clicked.connect(self._browse_ytdlp_path)
-        ytdlp_path_layout.addWidget(ytdlp_browse_btn)
-        paths_layout.addRow("yt-dlp Path:", ytdlp_path_layout)
+        ytdlp_path_row.addWidget(ytdlp_browse_btn)
+        paths_layout.addLayout(ytdlp_path_row)
 
-        # Help text
         paths_help = QLabel(
-            "Set custom paths if auto-detection fails. "
-            "Leave empty to use bundled or system binaries."
+            "Set custom paths if auto-detection fails. Leave empty to use bundled or system binaries."
         )
         paths_help.setObjectName("subtitle")
         paths_help.setWordWrap(True)
-        paths_layout.addRow("", paths_help)
+        paths_layout.addWidget(paths_help)
 
         layout.addWidget(paths_group)
 
@@ -408,36 +408,57 @@ class SettingsView(QWidget):
 
     def _check_ytdlp_status(self):
         """Check yt-dlp installation and version status."""
-        update_info = check_ytdlp_updates()
+        import shutil
+        import subprocess
 
-        if not update_info:
+        version = None
+        found = False
+
+        # Check custom path from config first (instant, no subprocess)
+        custom_path = self.config.get("ytdlp_path", "")
+        if custom_path and os.path.isfile(custom_path):
+            found = True
+            try:
+                result = subprocess.run(
+                    [custom_path, "--version"],
+                    capture_output=True, text=True, timeout=3
+                )
+                if result.returncode == 0:
+                    version = result.stdout.strip()
+            except Exception:
+                pass
+        else:
+            # Check PATH
+            ytdlp_bin = shutil.which("yt-dlp")
+            if ytdlp_bin:
+                found = True
+                try:
+                    result = subprocess.run(
+                        [ytdlp_bin, "--version"],
+                        capture_output=True, text=True, timeout=3
+                    )
+                    if result.returncode == 0:
+                        version = result.stdout.strip()
+                except Exception:
+                    pass
+
+        if found and version:
+            self.ytdlp_status_icon.setStyleSheet("color: #4caf50; font-size: 14px;")
+            self.ytdlp_status_label.setText(f"Installed: {version}")
+            self.ytdlp_status_label.setStyleSheet("color: #4caf50;")
+            self.ytdlp_update_btn.setText("Check for Updates")
+            self.ytdlp_update_btn.setEnabled(True)
+        elif found:
             self.ytdlp_status_icon.setStyleSheet("color: #ff9800; font-size: 14px;")
-            self.ytdlp_status_label.setText("Could not check version")
+            self.ytdlp_status_label.setText("Found but could not get version")
             self.ytdlp_status_label.setStyleSheet("color: #ff9800;")
-            self.ytdlp_update_btn.setEnabled(False)
-            return
-
-        current_version = update_info.get("current_version")
-        has_update = update_info.get("update_available", False)
-
-        if not current_version:
+            self.ytdlp_update_btn.setText("Check for Updates")
+            self.ytdlp_update_btn.setEnabled(True)
+        else:
             self.ytdlp_status_icon.setStyleSheet("color: #ef5350; font-size: 14px;")
             self.ytdlp_status_label.setText("Not installed")
             self.ytdlp_status_label.setStyleSheet("color: #ef5350;")
             self.ytdlp_update_btn.setText("Install yt-dlp")
-            self.ytdlp_update_btn.setEnabled(True)
-        elif has_update:
-            latest_version = update_info.get("latest_version")
-            self.ytdlp_status_icon.setStyleSheet("color: #ff9800; font-size: 14px;")
-            self.ytdlp_status_label.setText(f"Update available: {current_version} → {latest_version}")
-            self.ytdlp_status_label.setStyleSheet("color: #ff9800;")
-            self.ytdlp_update_btn.setText("Update yt-dlp")
-            self.ytdlp_update_btn.setEnabled(True)
-        else:
-            self.ytdlp_status_icon.setStyleSheet("color: #4caf50; font-size: 14px;")
-            self.ytdlp_status_label.setText(f"Up to date: {current_version}")
-            self.ytdlp_status_label.setStyleSheet("color: #4caf50;")
-            self.ytdlp_update_btn.setText("Check for Updates")
             self.ytdlp_update_btn.setEnabled(True)
 
     def _check_ytdlp_updates(self):
@@ -502,24 +523,23 @@ class SettingsView(QWidget):
 
     def _on_ytdlp_finished(self, success: bool, message: str):
         """Handle yt-dlp update completion."""
-        # Hide progress
         self.ytdlp_progress.setVisible(False)
         self.ytdlp_progress_label.setVisible(False)
-
-        # Re-enable buttons
         self.ytdlp_update_btn.setEnabled(True)
         self.ytdlp_refresh_btn.setEnabled(True)
 
-        # Show result
         if success:
+            # Ensure newly installed binary's dir is on PATH
+            if hasattr(self.ytdlp_worker, 'install_dir'):
+                install_dir = self.ytdlp_worker.install_dir
+                if install_dir not in os.environ.get('PATH', ''):
+                    os.environ['PATH'] = install_dir + os.pathsep + os.environ.get('PATH', '')
             QMessageBox.information(self, "Success", message)
-            self._check_ytdlp_status()
         else:
-            QMessageBox.warning(self, "Update Failed", message)
-            self._check_ytdlp_status()
+            QMessageBox.warning(self, "Install Failed", message)
 
-        # Clean up worker
         self.ytdlp_worker = None
+        self._check_ytdlp_status()
 
     def _browse_ffmpeg_path(self):
         """Open file browser for FFmpeg binary."""

--- a/gui/workers/ytdlp_installer.py
+++ b/gui/workers/ytdlp_installer.py
@@ -30,8 +30,13 @@ class YtdlpInstallerWorker(QThread):
         self._cancelled = False
 
         if install_dir is None:
-            if getattr(sys, 'frozen', False):
-                # Frozen app: install next to the executable
+            if getattr(sys, 'frozen', False) and sys.platform == "darwin":
+                # macOS .app bundle: use user-writable location
+                self.install_dir = os.path.join(
+                    os.path.expanduser("~/Library/Application Support/HARMONI"), "bin"
+                )
+            elif getattr(sys, 'frozen', False):
+                # Windows/Linux frozen: install next to the executable
                 self.install_dir = os.path.join(os.path.dirname(sys.executable), "bin")
             else:
                 # Dev mode: install in project_root/bin

--- a/gui/workers/ytdlp_installer.py
+++ b/gui/workers/ytdlp_installer.py
@@ -1,0 +1,128 @@
+"""yt-dlp installer worker for downloading the standalone binary."""
+
+import os
+import sys
+import stat
+import shutil
+import tempfile
+from urllib.request import urlopen, Request
+from urllib.error import URLError
+
+from PySide6.QtCore import QThread, Signal
+
+
+# yt-dlp standalone binary URLs from GitHub releases
+YTDLP_URLS = {
+    "win32": "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe",
+    "darwin": "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos",
+    "linux": "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux",
+}
+
+
+class YtdlpInstallerWorker(QThread):
+    """Worker thread for downloading and installing the yt-dlp binary."""
+
+    progress = Signal(int, str)
+    finished = Signal(bool, str)
+
+    def __init__(self, install_dir: str = None, parent=None):
+        super().__init__(parent)
+        self._cancelled = False
+
+        if install_dir is None:
+            if getattr(sys, 'frozen', False):
+                # Frozen app: install next to the executable
+                self.install_dir = os.path.join(os.path.dirname(sys.executable), "bin")
+            else:
+                # Dev mode: install in project_root/bin
+                project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+                self.install_dir = os.path.join(project_root, "bin")
+        else:
+            self.install_dir = install_dir
+
+    def cancel(self):
+        self._cancelled = True
+
+    def run(self):
+        try:
+            platform = "darwin" if sys.platform == "darwin" else sys.platform
+            url = YTDLP_URLS.get(platform)
+            if not url:
+                self.finished.emit(False, f"No yt-dlp download available for {sys.platform}")
+                return
+
+            self.progress.emit(0, "Preparing download...")
+
+            binary_name = "yt-dlp.exe" if sys.platform == "win32" else "yt-dlp"
+            dest_path = os.path.join(self.install_dir, binary_name)
+
+            temp_dir = tempfile.mkdtemp()
+            temp_path = os.path.join(temp_dir, binary_name)
+
+            try:
+                self.progress.emit(5, "Connecting...")
+
+                request = Request(url, headers={"User-Agent": "HARMONI/1.0"})
+                response = urlopen(request, timeout=30)
+
+                total_size = int(response.headers.get("content-length", 0))
+                downloaded = 0
+                block_size = 256 * 1024  # 256KB blocks
+
+                self.progress.emit(10, "Downloading yt-dlp...")
+
+                with open(temp_path, "wb") as f:
+                    while True:
+                        if self._cancelled:
+                            self.finished.emit(False, "Download cancelled")
+                            return
+
+                        block = response.read(block_size)
+                        if not block:
+                            break
+
+                        f.write(block)
+                        downloaded += len(block)
+
+                        if total_size > 0:
+                            percent = int(10 + (downloaded / total_size) * 70)
+                            size_mb = downloaded / (1024 * 1024)
+                            total_mb = total_size / (1024 * 1024)
+                            self.progress.emit(percent, f"Downloading... {size_mb:.1f} / {total_mb:.1f} MB")
+
+                self.progress.emit(85, "Installing...")
+
+                # Make executable on Unix
+                if sys.platform != "win32":
+                    os.chmod(temp_path, os.stat(temp_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+                # Move to install dir
+                os.makedirs(self.install_dir, exist_ok=True)
+                if os.path.exists(dest_path):
+                    os.remove(dest_path)
+                shutil.move(temp_path, dest_path)
+
+                # Add to PATH if not already there
+                if self.install_dir not in os.environ.get('PATH', ''):
+                    os.environ['PATH'] = self.install_dir + os.pathsep + os.environ.get('PATH', '')
+
+                self.progress.emit(95, "Verifying...")
+
+                if os.path.exists(dest_path):
+                    self.progress.emit(100, "yt-dlp installed successfully!")
+                    self.finished.emit(True, f"yt-dlp installed to:\n{self.install_dir}")
+                else:
+                    self.finished.emit(False, "Installation verification failed")
+
+            finally:
+                try:
+                    shutil.rmtree(temp_dir, ignore_errors=True)
+                except Exception:
+                    pass
+
+        except URLError as e:
+            self.finished.emit(False, f"Download failed: {e.reason}")
+        except PermissionError:
+            self.finished.emit(False, f"Permission denied writing to:\n{self.install_dir}")
+        except Exception as e:
+            self.finished.emit(False, f"Installation failed: {str(e)}")

--- a/gui_main.py
+++ b/gui_main.py
@@ -73,11 +73,38 @@ def create_default_config():
 
 def configure_bundled_binaries():
     """Add bundled bin/ directory to PATH so ffmpeg and yt-dlp are found."""
-    from utils.ffmpeg import configure_ffmpeg_path
-    try:
-        configure_ffmpeg_path()
-    except FileNotFoundError:
-        pass  # ffmpeg not bundled, will be handled later
+    import sys
+    import stat
+
+    bin_dir = None
+
+    # Check for bundled bin/ in PyInstaller bundle
+    if getattr(sys, 'frozen', False):
+        candidate = os.path.join(sys._MEIPASS, 'bin')
+        if os.path.isdir(candidate):
+            bin_dir = candidate
+
+    # Fallback: check for a local bin/ next to the script/executable
+    if not bin_dir:
+        candidate = os.path.join(get_app_dir(), 'bin')
+        if os.path.isdir(candidate):
+            bin_dir = candidate
+
+    if not bin_dir:
+        return
+
+    # Ensure all binaries in bin/ are executable (PyInstaller may strip permissions)
+    for name in os.listdir(bin_dir):
+        fpath = os.path.join(bin_dir, name)
+        if os.path.isfile(fpath):
+            try:
+                st = os.stat(fpath)
+                if not (st.st_mode & stat.S_IEXEC):
+                    os.chmod(fpath, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+            except OSError:
+                pass  # read-only bundle (e.g. /Applications), skip
+
+    os.environ['PATH'] = bin_dir + os.pathsep + os.environ.get('PATH', '')
 
 
 def check_ffmpeg():

--- a/gui_main.py
+++ b/gui_main.py
@@ -100,10 +100,16 @@ def configure_bundled_binaries():
         if os.path.isdir(candidate):
             paths_to_add.append(candidate)
 
-    # Fallback: check for a local bin/ next to the script/executable
+    # Check for a local bin/ next to the script/executable
     app_bin = os.path.join(get_app_dir(), 'bin')
     if os.path.isdir(app_bin) and app_bin not in paths_to_add:
         paths_to_add.append(app_bin)
+
+    # macOS: also check user-writable location where the installer puts binaries
+    if sys.platform == 'darwin':
+        user_bin = os.path.join(os.path.expanduser("~/Library/Application Support/HARMONI"), "bin")
+        if os.path.isdir(user_bin) and user_bin not in paths_to_add:
+            paths_to_add.append(user_bin)
 
     # Ensure binaries are executable and add to PATH
     for bin_dir in paths_to_add:

--- a/gui_main.py
+++ b/gui_main.py
@@ -72,39 +72,54 @@ def create_default_config():
 
 
 def configure_bundled_binaries():
-    """Add bundled bin/ directory to PATH so ffmpeg and yt-dlp are found."""
+    """Add bundled/custom bin directories to PATH so ffmpeg and yt-dlp are found."""
     import sys
     import stat
 
-    bin_dir = None
+    paths_to_add = []
+
+    # Check config for custom paths first
+    try:
+        config_path = os.path.join(get_app_dir(), "config.json")
+        if os.path.exists(config_path):
+            import json
+            with open(config_path, "r") as f:
+                cfg = json.load(f)
+            for key in ("ffmpeg_path", "ytdlp_path"):
+                custom = cfg.get(key, "")
+                if custom and os.path.isfile(custom):
+                    custom_dir = os.path.dirname(custom)
+                    if custom_dir not in paths_to_add:
+                        paths_to_add.append(custom_dir)
+    except Exception:
+        pass
 
     # Check for bundled bin/ in PyInstaller bundle
     if getattr(sys, 'frozen', False):
         candidate = os.path.join(sys._MEIPASS, 'bin')
         if os.path.isdir(candidate):
-            bin_dir = candidate
+            paths_to_add.append(candidate)
 
     # Fallback: check for a local bin/ next to the script/executable
-    if not bin_dir:
-        candidate = os.path.join(get_app_dir(), 'bin')
-        if os.path.isdir(candidate):
-            bin_dir = candidate
+    app_bin = os.path.join(get_app_dir(), 'bin')
+    if os.path.isdir(app_bin) and app_bin not in paths_to_add:
+        paths_to_add.append(app_bin)
 
-    if not bin_dir:
-        return
+    # Ensure binaries are executable and add to PATH
+    for bin_dir in paths_to_add:
+        for name in os.listdir(bin_dir):
+            fpath = os.path.join(bin_dir, name)
+            if os.path.isfile(fpath):
+                try:
+                    st = os.stat(fpath)
+                    if not (st.st_mode & stat.S_IEXEC):
+                        os.chmod(fpath, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+                except OSError:
+                    pass
 
-    # Ensure all binaries in bin/ are executable (PyInstaller may strip permissions)
-    for name in os.listdir(bin_dir):
-        fpath = os.path.join(bin_dir, name)
-        if os.path.isfile(fpath):
-            try:
-                st = os.stat(fpath)
-                if not (st.st_mode & stat.S_IEXEC):
-                    os.chmod(fpath, st.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-            except OSError:
-                pass  # read-only bundle (e.g. /Applications), skip
-
-    os.environ['PATH'] = bin_dir + os.pathsep + os.environ.get('PATH', '')
+    if paths_to_add:
+        current = os.environ.get('PATH', '')
+        os.environ['PATH'] = os.pathsep.join(paths_to_add) + os.pathsep + current
 
 
 def check_ffmpeg():

--- a/gui_main.py
+++ b/gui_main.py
@@ -71,6 +71,15 @@ def create_default_config():
             print(f"Created default config.json")
 
 
+def configure_bundled_binaries():
+    """Add bundled bin/ directory to PATH so ffmpeg and yt-dlp are found."""
+    from utils.ffmpeg import configure_ffmpeg_path
+    try:
+        configure_ffmpeg_path()
+    except FileNotFoundError:
+        pass  # ffmpeg not bundled, will be handled later
+
+
 def check_ffmpeg():
     """Check if FFmpeg is available."""
     from utils.ffmpeg import check_ffmpeg_available
@@ -98,6 +107,9 @@ def main():
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_id)
         except Exception:
             pass
+
+    # Set up bundled binaries (ffmpeg, yt-dlp) before anything checks for them
+    configure_bundled_binaries()
 
     # Check dependencies first
     check_dependencies()

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,12 @@ A Python tool for downloading music from Spotify and YouTube using **yt-dlp**. A
 
 ### Option 1: Standalone Executable (Easiest)
 
-Download `HARMONI.exe` from the [Releases](https://github.com/Ssenseii/spotify-yt-dlp-downloader/releases) page. No Python installation required.
+Download from the [Releases](https://github.com/Ssenseii/harmoni/releases) page:
+
+- **Windows**: `HARMONI.exe` — double-click to run
+- **macOS**: `HARMONI-macos-arm64.dmg` (Apple Silicon) — open the DMG and drag HARMONI to Applications
+
+No Python installation required. FFmpeg is bundled.
 
 See [Standalone Guide](docs/guides/standalone.md) for details.
 
@@ -28,8 +33,8 @@ See [Standalone Guide](docs/guides/standalone.md) for details.
 
 ```bash
 # Clone and install
-git clone https://github.com/Ssenseii/spotify-yt-dlp-downloader.git
-cd spotify-yt-dlp-downloader
+git clone https://github.com/Ssenseii/harmoni.git
+cd harmoni
 pip install -r requirements.txt
 
 # Run the GUI
@@ -43,8 +48,19 @@ python main.py
 
 ```bash
 docker compose build
-docker compose run --rm --service-ports spotify-yt-dlp-downloader
+docker compose run --rm --service-ports harmoni
 ```
+
+### Option 4: Build macOS from Source
+
+On any Mac with Python 3.12+ and Homebrew:
+
+```bash
+chmod +x build-macos.sh
+./build-macos.sh
+```
+
+This produces a `HARMONI-macos-<arch>.dmg` with ffmpeg bundled.
 
 ## Quick Start
 
@@ -52,7 +68,7 @@ docker compose run --rm --service-ports spotify-yt-dlp-downloader
 
 The easiest way to download your Spotify music:
 
-1. Launch `HARMONI.exe` or run `python gui_main.py`
+1. Launch HARMONI (exe, app, or `python gui_main.py`)
 2. Go to [exportify.net](https://exportify.net) and log in with Spotify
 3. Export your playlists as CSV files
 4. Drag and drop the CSV into HARMONI
@@ -81,7 +97,7 @@ See [CLI Guide](docs/guides/cli.md) for all available commands.
 
 ## Requirements
 
-- **Standalone EXE**: None (ffmpeg bundled)
+- **Standalone EXE/DMG**: None (ffmpeg bundled)
 - **Python version**: Python 3.9+ and ffmpeg
 
 ## Documentation

--- a/spotify_api/auth.py
+++ b/spotify_api/auth.py
@@ -99,7 +99,7 @@ def spotify_app_setup_instructions(*, redirect_uri: str = "http://127.0.0.1:8888
         "1) Go to https://developer.spotify.com/dashboard\n"
         "2) Create an app (or select an existing app)\n"
         f"3) Add this Redirect URI in the app settings: {redirect_uri}\n"
-        "4) Copy the Client ID into spotify-yt-dlp-downloader/config.json as spotify_client_id\n"
+        "4) Copy the Client ID into harmoni/config.json as spotify_client_id\n"
         "5) Keep spotify_scopes as-is unless you know you need different permissions\n\n"
         "Notes:\n"
         "- This project uses Authorization Code + PKCE (no client secret required).\n"


### PR DESCRIPTION
## What this does

Adds macOS binary builds for HARMONI both via GitHub Actions CI and a local build script so macOS users can download and run the app without needing extra configuration steps.

I implemented this because I wanted to help a friend out to be able to use this, local script included so that this doesn't rely on workers. 

#### Installs via installer
<img width="417" height="223" alt="harmoni-installer-1" src="https://github.com/user-attachments/assets/8328449d-8291-4049-99f3-e2400983f644" />

#### Working downloads
<img width="1187" height="684" alt="Working Downloads" src="https://github.com/user-attachments/assets/52a315cf-7348-4747-9af0-82b129444cdd" />


### Updating yt-dlp install & adding custom paths + UI Fixes
<img width="960" height="572" alt="image" src="https://github.com/user-attachments/assets/f464bda2-70a6-40fe-b4b8-8feb2974840b" />

Also updates all documentation references from the old repo name (`spotify-yt-dlp-downloader`) to `harmoni`.

### Doc updates

- Renamed `spotify-yt-dlp-downloader` to `harmoni` in readme, docs, docker-compose, installation guide, docker guide, standalone guide, and `spotify_api/auth.py` to align with repo name update
- Added macOS install instructions to the standalone guide
- Updated readme with macOS download option and build-from-source instructions

### yt-dlp standalone installer

- Added a standalone yt-dlp binary installer (`gui/workers/ytdlp_installer.py`) that downloads the yt-dlp binary from GitHub releases when it's not found on the system
- Works on macOS, Windows, and Linux — no pip or Python required on the user's end
- The settings view now uses this installer for fresh installs, and falls back to the existing pip-based updater for version updates
- Bundled binaries (ffmpeg, ffprobe, yt-dlp) are added to PATH at startup so the app detects them properly
- Handles read-only install locations gracefully (e.g. `/Applications` on macOS)

##### Link to github action runs with build outputs
[https://github.com/astralfragment/harmoni/actions/runs/23465595400](https://github.com/astralfragment/harmoni/actions/runs/23465595400)