### PR TITLE
 Fix Spotify track selection and playlist loading + QOL Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 
 # Internal documentation (not for public release)
 docs/internal/
+data/spotify_cache.json

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -349,6 +349,7 @@ class MainWindow(QMainWindow):
             self.youtube_view.config = self.config
             self.downloads_view.config = self.config
             self.welcome_view.config = self.config
+            self.settings_view.config = self.config
             self.status_label.setText("Settings saved successfully")
         except Exception as e:
             self.status_label.setText(f"Error reloading config: {e}")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -284,6 +284,18 @@ class MainWindow(QMainWindow):
         spacer.setFixedWidth(20)
         status_bar.addWidget(spacer)
 
+        import_btn = QPushButton("Import CSV")
+        import_btn.setObjectName("ghost")
+        import_btn.setStyleSheet("font-size: 11px; padding: 2px 8px; min-width: 0;")
+        import_btn.clicked.connect(self._quick_import_csv)
+        status_bar.addPermanentWidget(import_btn)
+
+        exportify_btn = QPushButton("Exportify")
+        exportify_btn.setObjectName("ghost")
+        exportify_btn.setStyleSheet("font-size: 11px; padding: 2px 8px; min-width: 0;")
+        exportify_btn.clicked.connect(self._open_exportify)
+        status_bar.addPermanentWidget(exportify_btn)
+
         # Download count
         self.download_count_label = QLabel("Queue: 0")
         status_bar.addPermanentWidget(self.download_count_label)
@@ -353,6 +365,16 @@ class MainWindow(QMainWindow):
             self.status_label.setText("Settings saved successfully")
         except Exception as e:
             self.status_label.setText(f"Error reloading config: {e}")
+
+    def _quick_import_csv(self):
+        from PySide6.QtWidgets import QFileDialog
+        files, _ = QFileDialog.getOpenFileNames(self, "Import Exportify CSV", "", "CSV Files (*.csv)")
+        if files:
+            self.welcome_view._handle_dropped_files(files)
+
+    def _open_exportify(self):
+        import webbrowser
+        webbrowser.open("https://exportify.net")
 
     def set_status(self, message: str):
         """Set status bar message."""

--- a/gui/styles.py
+++ b/gui/styles.py
@@ -34,7 +34,7 @@ QMainWindow {{
 QWidget {{
     background-color: {COLORS["background"]};
     color: {COLORS["text"]};
-    font-family: 'Segoe UI', 'SF Pro Display', -apple-system, Arial, sans-serif;
+    font-family: 'Helvetica Neue', 'Segoe UI', Arial;
     font-size: 14px;
 }}
 
@@ -285,6 +285,8 @@ QTableWidget {{
     border-radius: 10px;
     gridline-color: {COLORS["border"]};
     outline: none;
+    selection-background-color: {COLORS["accent_muted"]};
+    selection-color: {COLORS["text"]};
 }}
 
 QTableWidget::item {{
@@ -292,13 +294,13 @@ QTableWidget::item {{
     border: none;
 }}
 
+QTableWidget::item:hover:!selected {{
+    background-color: {COLORS["background_light"]};
+}}
+
 QTableWidget::item:selected {{
     background-color: {COLORS["accent_muted"]};
     color: {COLORS["text"]};
-}}
-
-QTableWidget::item:hover {{
-    background-color: {COLORS["background_light"]};
 }}
 
 QHeaderView::section {{

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -576,6 +576,7 @@ class SettingsView(QWidget):
     def _save_settings(self):
         """Save current settings to config."""
         try:
+            # Update config dict
             output_dir = self.output_dir_input.text().strip()
             if not output_dir:
                 output_dir = "music"

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -564,24 +564,32 @@ class SettingsView(QWidget):
         except Exception:
             pass  # Silently fail for individual updates
 
+    def _safe_int(self, text: str, default: int) -> int:
+        text = text.strip()
+        if not text:
+            return default
+        try:
+            return int(text)
+        except ValueError:
+            return default
+
     def _save_settings(self):
         """Save current settings to config."""
         try:
-            # Update config dict
             output_dir = self.output_dir_input.text().strip()
             if not output_dir:
                 output_dir = "music"
 
             self.config["output_dir"] = output_dir
             self.config["audio_format"] = self.format_combo.currentText()
-            self.config["spotify_client_id"] = self.client_id_input.text()
-            self.config["sleep_between"] = int(self.sleep_input.text() or 5)
-            self.config["retry_attempts"] = int(self.retry_input.text() or 3)
+            self.config["spotify_client_id"] = self.client_id_input.text().strip()
+            self.config["sleep_between"] = self._safe_int(self.sleep_input.text(), 5)
+            self.config["retry_attempts"] = self._safe_int(self.retry_input.text(), 3)
             self.config["enable_metadata_embedding"] = self.metadata_check.isChecked()
             self.config["metadata_template"] = self.template_combo.currentText()
             self.config["enable_musicbrainz_lookup"] = self.musicbrainz_check.isChecked()
             self.config["auto_backup"] = self.backup_check.isChecked()
-            self.config["max_backups"] = int(self.max_backups_input.text() or 10)
+            self.config["max_backups"] = self._safe_int(self.max_backups_input.text(), 10)
             self.config["ffmpeg_path"] = self.ffmpeg_path_input.text().strip()
             self.config["ytdlp_path"] = self.ytdlp_path_input.text().strip()
 

--- a/gui/views/spotify_view.py
+++ b/gui/views/spotify_view.py
@@ -1,13 +1,15 @@
 """Spotify view for browsing playlists and downloading tracks."""
 
+import os
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QTableWidget, QTableWidgetItem,
     QHeaderView, QListWidget, QListWidgetItem,
-    QSplitter, QGroupBox, QProgressBar, QMessageBox,
-    QCheckBox, QAbstractItemView, QFrame
+    QSplitter, QProgressBar, QMessageBox,
+    QCheckBox, QAbstractItemView, QMenu
 )
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QAction
 
 from gui.workers.download_queue import DownloadQueue
 from gui.workers.spotify_worker import SpotifyWorker
@@ -19,7 +21,7 @@ from spotify_api.token_manager import TokenManager
 class SpotifyView(QWidget):
     """View for Spotify playlist browsing and track selection."""
 
-    connection_changed = Signal(bool)  # Emits connection status
+    connection_changed = Signal(bool)
 
     def __init__(self, config: dict, queue: DownloadQueue, parent=None):
         super().__init__(parent)
@@ -27,25 +29,22 @@ class SpotifyView(QWidget):
         self.queue = queue
         self.worker = None
         self.current_tracks = []
+        self._updating_checks = False
         self._setup_ui()
         self._check_connection()
 
     def _setup_ui(self):
-        """Set up the Spotify UI."""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(40, 30, 40, 30)
         layout.setSpacing(20)
 
         # Header
         header_layout = QHBoxLayout()
-
         title = QLabel("Spotify")
         title.setObjectName("title")
         header_layout.addWidget(title)
-
         header_layout.addStretch()
 
-        # Connection status
         self.status_label = QLabel("Not connected")
         self.status_label.setObjectName("subtitle")
         header_layout.addWidget(self.status_label)
@@ -53,15 +52,12 @@ class SpotifyView(QWidget):
         self.connect_btn = QPushButton("Connect to Spotify")
         self.connect_btn.clicked.connect(self._show_oauth_dialog)
         header_layout.addWidget(self.connect_btn)
-
         layout.addLayout(header_layout)
 
-        # Progress bar for loading
         self.progress_bar = QProgressBar()
         self.progress_bar.hide()
         layout.addWidget(self.progress_bar)
 
-        # Main content splitter
         splitter = QSplitter(Qt.Horizontal)
 
         # Left panel - Playlists
@@ -73,26 +69,26 @@ class SpotifyView(QWidget):
         playlists_label.setObjectName("section")
         left_layout.addWidget(playlists_label)
 
-        # Refresh button
-        refresh_layout = QHBoxLayout()
+        btn_row = QHBoxLayout()
         self.refresh_btn = QPushButton("Refresh")
         self.refresh_btn.setObjectName("secondary")
         self.refresh_btn.clicked.connect(self._refresh_playlists)
         self.refresh_btn.setEnabled(False)
-        refresh_layout.addWidget(self.refresh_btn)
+        btn_row.addWidget(self.refresh_btn)
 
         self.liked_btn = QPushButton("Liked Songs")
         self.liked_btn.setObjectName("secondary")
         self.liked_btn.clicked.connect(self._fetch_liked_songs)
         self.liked_btn.setEnabled(False)
-        refresh_layout.addWidget(self.liked_btn)
+        btn_row.addWidget(self.liked_btn)
 
-        refresh_layout.addStretch()
-        left_layout.addLayout(refresh_layout)
+        btn_row.addStretch()
+        left_layout.addLayout(btn_row)
 
-        # Playlist list
         self.playlist_list = QListWidget()
         self.playlist_list.itemClicked.connect(self._on_playlist_selected)
+        self.playlist_list.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.playlist_list.customContextMenuRequested.connect(self._show_playlist_context_menu)
         left_layout.addWidget(self.playlist_list)
 
         splitter.addWidget(left_panel)
@@ -102,22 +98,17 @@ class SpotifyView(QWidget):
         right_layout = QVBoxLayout(right_panel)
         right_layout.setContentsMargins(10, 0, 0, 0)
 
-        # Tracks header
         tracks_header = QHBoxLayout()
         self.tracks_label = QLabel("Tracks")
         self.tracks_label.setObjectName("section")
         tracks_header.addWidget(self.tracks_label)
-
         tracks_header.addStretch()
 
-        # Select all checkbox
         self.select_all_check = QCheckBox("Select All")
         self.select_all_check.stateChanged.connect(self._toggle_select_all)
         tracks_header.addWidget(self.select_all_check)
-
         right_layout.addLayout(tracks_header)
 
-        # Tracks table
         self.tracks_table = QTableWidget()
         self.tracks_table.setColumnCount(4)
         self.tracks_table.setHorizontalHeaderLabels(["", "Artist", "Track", "Album"])
@@ -127,38 +118,33 @@ class SpotifyView(QWidget):
         self.tracks_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
         self.tracks_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch)
         self.tracks_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tracks_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.tracks_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.tracks_table.verticalHeader().setVisible(False)
+        self.tracks_table.setShowGrid(False)
+        self.tracks_table.itemChanged.connect(self._on_item_changed)
+        self.tracks_table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.tracks_table.customContextMenuRequested.connect(self._show_context_menu)
         right_layout.addWidget(self.tracks_table)
 
-        # Add to queue button
-        btn_layout = QHBoxLayout()
-        btn_layout.addStretch()
-
+        footer = QHBoxLayout()
+        footer.addStretch()
         self.track_count_label = QLabel("0 tracks selected")
-        btn_layout.addWidget(self.track_count_label)
-
+        footer.addWidget(self.track_count_label)
         self.add_btn = QPushButton("Add to Download Queue")
         self.add_btn.clicked.connect(self._add_selected_to_queue)
         self.add_btn.setEnabled(False)
-        btn_layout.addWidget(self.add_btn)
-
-        right_layout.addLayout(btn_layout)
+        footer.addWidget(self.add_btn)
+        right_layout.addLayout(footer)
 
         splitter.addWidget(right_panel)
-
-        # Set splitter proportions
         splitter.setSizes([300, 700])
-
         layout.addWidget(splitter, 1)
 
     def _check_connection(self):
-        """Check if we have a valid Spotify token."""
         auth = SpotifyPKCEAuth(self.config)
         token = auth.load_cached_token()
-
         if token and token.access_token:
-            # Check if expired
             if TokenManager.is_expired(token):
                 if token.refresh_token:
                     try:
@@ -174,7 +160,6 @@ class SpotifyView(QWidget):
             self._set_connected(False)
 
     def _set_connected(self, connected: bool):
-        """Update UI based on connection status."""
         if connected:
             self.status_label.setText("Connected")
             self.status_label.setStyleSheet("color: #1db954;")
@@ -182,7 +167,6 @@ class SpotifyView(QWidget):
             self.refresh_btn.setEnabled(True)
             self.liked_btn.setEnabled(True)
             self.connection_changed.emit(True)
-            # Auto-refresh playlists
             self._refresh_playlists()
         else:
             self.status_label.setText("Not connected")
@@ -193,178 +177,269 @@ class SpotifyView(QWidget):
             self.connection_changed.emit(False)
 
     def _show_oauth_dialog(self):
-        """Show the OAuth login dialog."""
         dialog = SpotifyOAuthDialog(self.config, self)
         dialog.auth_completed.connect(self._on_auth_completed)
         dialog.exec()
 
     def _on_auth_completed(self, success: bool, message: str):
-        """Handle OAuth completion."""
         if success:
             self._set_connected(True)
         else:
             QMessageBox.warning(self, "Authentication Failed", message)
 
+    def _prompt_reconnect(self):
+        reply = QMessageBox.question(
+            self, "Session Expired",
+            "Your Spotify session has expired.\nReconnect now?",
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes,
+        )
+        if reply == QMessageBox.Yes:
+            self._show_oauth_dialog()
+
     def _refresh_playlists(self):
-        """Refresh the playlist list."""
         if self.worker and self.worker.isRunning():
             return
-
         self.worker = SpotifyWorker(self.config)
         self.worker.playlists_loaded.connect(self._on_playlists_loaded)
         self.worker.error.connect(self._on_error)
         self.worker.progress.connect(self._on_progress)
         self.worker.fetch_playlists()
-
         self.progress_bar.setRange(0, 0)
         self.progress_bar.show()
         self.refresh_btn.setEnabled(False)
 
     def _on_playlists_loaded(self, playlists: list):
-        """Handle playlists loaded."""
         self.progress_bar.hide()
         self.refresh_btn.setEnabled(True)
-
         self.playlist_list.clear()
         for playlist in playlists:
-            item = QListWidgetItem(f"{playlist['name']} ({playlist['tracks_total']} tracks)")
+            count = playlist.get("tracks_total") or 0
+            name = playlist.get("name", "")
+            label = f"{name} ({count} tracks)" if count > 0 else name
+            item = QListWidgetItem(label)
             item.setData(Qt.UserRole, playlist)
             self.playlist_list.addItem(item)
 
+    def _update_playlist_track_count(self, playlist_id: str, count: int):
+        for i in range(self.playlist_list.count()):
+            item = self.playlist_list.item(i)
+            playlist = item.data(Qt.UserRole)
+            if playlist and playlist.get("id") == playlist_id:
+                playlist["tracks_total"] = count
+                item.setText(f"{playlist['name']} ({count} tracks)")
+                item.setData(Qt.UserRole, playlist)
+                break
+
     def _on_playlist_selected(self, item: QListWidgetItem):
-        """Handle playlist selection."""
         playlist = item.data(Qt.UserRole)
         if not playlist:
             return
-
         if self.worker and self.worker.isRunning():
             return
-
         self.worker = SpotifyWorker(self.config)
         self.worker.tracks_loaded.connect(self._on_tracks_loaded)
         self.worker.error.connect(self._on_error)
         self.worker.progress.connect(self._on_progress)
         self.worker.fetch_playlist_tracks(playlist["id"], playlist["name"])
-
         self.progress_bar.setRange(0, 0)
         self.progress_bar.show()
         self.tracks_label.setText(f"Tracks - {playlist['name']}")
 
     def _fetch_liked_songs(self):
-        """Fetch user's liked songs."""
         if self.worker and self.worker.isRunning():
             return
-
         self.worker = SpotifyWorker(self.config)
         self.worker.liked_songs_loaded.connect(self._on_liked_songs_loaded)
         self.worker.error.connect(self._on_error)
         self.worker.progress.connect(self._on_progress)
         self.worker.fetch_liked_songs()
-
         self.progress_bar.setRange(0, 0)
         self.progress_bar.show()
         self.liked_btn.setEnabled(False)
 
     def _on_liked_songs_loaded(self, tracks: list):
-        """Handle liked songs loaded."""
         self.progress_bar.hide()
         self.liked_btn.setEnabled(True)
         self.tracks_label.setText("Tracks - Liked Songs")
         self._populate_tracks(tracks)
 
     def _on_tracks_loaded(self, playlist_id: str, tracks: list):
-        """Handle tracks loaded."""
         self.progress_bar.hide()
         self._populate_tracks(tracks)
+        self._update_playlist_track_count(playlist_id, len(tracks))
 
     def _populate_tracks(self, tracks: list):
-        """Populate the tracks table."""
         self.current_tracks = tracks
+        self.tracks_table.blockSignals(True)
         self.tracks_table.setRowCount(0)
+        self.select_all_check.blockSignals(True)
         self.select_all_check.setChecked(False)
+        self.select_all_check.blockSignals(False)
 
         for track in tracks:
             row = self.tracks_table.rowCount()
             self.tracks_table.insertRow(row)
-
-            # Checkbox
-            checkbox = QCheckBox()
-            checkbox.stateChanged.connect(self._update_selection_count)
-            checkbox_widget = QWidget()
-            checkbox_layout = QHBoxLayout(checkbox_widget)
-            checkbox_layout.addWidget(checkbox)
-            checkbox_layout.setAlignment(Qt.AlignCenter)
-            checkbox_layout.setContentsMargins(0, 0, 0, 0)
-            self.tracks_table.setCellWidget(row, 0, checkbox_widget)
-
-            # Track data
+            check_item = QTableWidgetItem()
+            check_item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+            check_item.setCheckState(Qt.CheckState.Unchecked)
+            self.tracks_table.setItem(row, 0, check_item)
             self.tracks_table.setItem(row, 1, QTableWidgetItem(track.get("artist", "")))
             self.tracks_table.setItem(row, 2, QTableWidgetItem(track.get("track", "")))
             self.tracks_table.setItem(row, 3, QTableWidgetItem(track.get("album", "")))
 
+        self.tracks_table.blockSignals(False)
+        self.tracks_table.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self._update_selection_count()
         self.add_btn.setEnabled(len(tracks) > 0)
 
-    def _toggle_select_all(self, state: int):
-        """Toggle all checkboxes."""
-        checked = state == Qt.Checked
+    def _on_selection_changed(self):
+        if self._updating_checks:
+            return
+        self._updating_checks = True
+        selected_rows = {idx.row() for idx in self.tracks_table.selectionModel().selectedRows()}
+        self.tracks_table.blockSignals(True)
         for row in range(self.tracks_table.rowCount()):
-            widget = self.tracks_table.cellWidget(row, 0)
-            if widget:
-                checkbox = widget.findChild(QCheckBox)
-                if checkbox:
-                    checkbox.setChecked(checked)
+            item = self.tracks_table.item(row, 0)
+            if item:
+                item.setCheckState(Qt.CheckState.Checked if row in selected_rows else Qt.CheckState.Unchecked)
+        self.tracks_table.blockSignals(False)
+        self._updating_checks = False
+        self._update_selection_count()
+
+    def _on_item_changed(self, item: QTableWidgetItem):
+        if item.column() == 0 and not self._updating_checks:
+            self._update_selection_count()
+
+    def _toggle_select_all(self, state):
+        self._updating_checks = True
+        if bool(state):
+            self.tracks_table.selectAll()
+        else:
+            self.tracks_table.clearSelection()
+        target = Qt.CheckState.Checked if bool(state) else Qt.CheckState.Unchecked
+        self.tracks_table.blockSignals(True)
+        for row in range(self.tracks_table.rowCount()):
+            item = self.tracks_table.item(row, 0)
+            if item:
+                item.setCheckState(target)
+        self.tracks_table.blockSignals(False)
+        self._updating_checks = False
+        self._update_selection_count()
 
     def _update_selection_count(self):
-        """Update the selected track count label."""
         count = self._get_selected_count()
         self.track_count_label.setText(f"{count} tracks selected")
+        total = self.tracks_table.rowCount()
+        self.select_all_check.blockSignals(True)
+        self.select_all_check.setChecked(total > 0 and count == total)
+        self.select_all_check.blockSignals(False)
 
     def _get_selected_count(self) -> int:
-        """Get number of selected tracks."""
         count = 0
         for row in range(self.tracks_table.rowCount()):
-            widget = self.tracks_table.cellWidget(row, 0)
-            if widget:
-                checkbox = widget.findChild(QCheckBox)
-                if checkbox and checkbox.isChecked():
-                    count += 1
+            item = self.tracks_table.item(row, 0)
+            if item and item.checkState() == Qt.CheckState.Checked:
+                count += 1
         return count
 
     def _get_selected_tracks(self) -> list:
-        """Get list of selected tracks."""
         selected = []
         for row in range(self.tracks_table.rowCount()):
-            widget = self.tracks_table.cellWidget(row, 0)
-            if widget:
-                checkbox = widget.findChild(QCheckBox)
-                if checkbox and checkbox.isChecked():
-                    if row < len(self.current_tracks):
-                        selected.append(self.current_tracks[row])
+            item = self.tracks_table.item(row, 0)
+            if item and item.checkState() == Qt.CheckState.Checked:
+                if row < len(self.current_tracks):
+                    selected.append(self.current_tracks[row])
         return selected
 
+    def _show_context_menu(self, position):
+        if self.tracks_table.rowCount() == 0:
+            return
+        menu = QMenu(self)
+        count = self._get_selected_count()
+
+        dl = QAction(f"Download Selected ({count})", self)
+        dl.triggered.connect(self._add_selected_to_queue)
+        dl.setEnabled(count > 0)
+        menu.addAction(dl)
+        menu.addSeparator()
+
+        row = self.tracks_table.rowAt(position.y())
+        if 0 <= row < len(self.current_tracks):
+            t = self.current_tracks[row]
+            dl_one = QAction(f"Download \"{t.get('track', '')}\"", self)
+            dl_one.triggered.connect(lambda checked, r=row: self._add_single_to_queue(r))
+            menu.addAction(dl_one)
+            menu.addSeparator()
+
+        sa = QAction("Select All", self)
+        sa.triggered.connect(lambda: self._set_all_checked(True))
+        menu.addAction(sa)
+        da = QAction("Deselect All", self)
+        da.triggered.connect(lambda: self._set_all_checked(False))
+        menu.addAction(da)
+        inv = QAction("Invert Selection", self)
+        inv.triggered.connect(self._invert_selection)
+        menu.addAction(inv)
+        menu.exec(self.tracks_table.viewport().mapToGlobal(position))
+
+    def _show_playlist_context_menu(self, position):
+        if self.playlist_list.count() == 0:
+            return
+        menu = QMenu(self)
+        item = self.playlist_list.itemAt(position)
+        if item:
+            playlist = item.data(Qt.UserRole)
+            if playlist:
+                load = QAction(f"Load \"{playlist.get('name', '')}\"", self)
+                load.triggered.connect(lambda checked, i=item: self._on_playlist_selected(i))
+                menu.addAction(load)
+        menu.exec(self.playlist_list.viewport().mapToGlobal(position))
+
+    def _set_all_checked(self, checked: bool):
+        self.select_all_check.blockSignals(True)
+        self.select_all_check.setChecked(checked)
+        self.select_all_check.blockSignals(False)
+        self._toggle_select_all(2 if checked else 0)
+
+    def _invert_selection(self):
+        self._updating_checks = True
+        for row in range(self.tracks_table.rowCount()):
+            item = self.tracks_table.item(row, 0)
+            if item:
+                if item.checkState() == Qt.CheckState.Checked:
+                    item.setCheckState(Qt.CheckState.Unchecked)
+                else:
+                    item.setCheckState(Qt.CheckState.Checked)
+        self._updating_checks = False
+        self._update_selection_count()
+
+    def _add_single_to_queue(self, row: int):
+        if row < len(self.current_tracks):
+            track = self.current_tracks[row]
+            playlist_name = self.tracks_label.text().replace("Tracks - ", "")
+            self.queue.add_track(
+                track.get("artist", "").strip(),
+                track.get("track", "").strip(),
+                playlist_name,
+            )
+            QMessageBox.information(
+                self, "Added to Queue",
+                f"Added \"{track.get('track', '')}\" by {track.get('artist', '')} to download queue.",
+            )
+
     def _add_selected_to_queue(self):
-        """Add selected tracks to download queue."""
         tracks = self._get_selected_tracks()
         if not tracks:
             QMessageBox.information(self, "No Selection", "Please select tracks to download.")
             return
-
-        # Get playlist name for the queue
         playlist_name = self.tracks_label.text().replace("Tracks - ", "")
-
-        # Add to queue
         self.queue.add_tracks(tracks, playlist=playlist_name)
-
         QMessageBox.information(
-            self,
-            "Added to Queue",
-            f"Added {len(tracks)} tracks to download queue.\n\n"
-            "Go to Downloads to start downloading."
+            self, "Added to Queue",
+            f"Added {len(tracks)} tracks to download queue.\n\nGo to Downloads to start downloading.",
         )
 
     def _on_progress(self, message: str, current: int, total: int):
-        """Handle progress updates."""
         if total > 0:
             self.progress_bar.setRange(0, total)
             self.progress_bar.setValue(current)
@@ -372,8 +447,12 @@ class SpotifyView(QWidget):
             self.progress_bar.setRange(0, 0)
 
     def _on_error(self, message: str):
-        """Handle errors."""
         self.progress_bar.hide()
         self.refresh_btn.setEnabled(True)
         self.liked_btn.setEnabled(True)
-        QMessageBox.warning(self, "Error", message)
+        msg_lower = message.lower()
+        if "401" in message or "token" in msg_lower or "expired" in msg_lower:
+            self._set_connected(False)
+            self._prompt_reconnect()
+        else:
+            QMessageBox.warning(self, "Error", message)

--- a/gui/views/spotify_view.py
+++ b/gui/views/spotify_view.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
     QSplitter, QProgressBar, QMessageBox,
     QCheckBox, QAbstractItemView, QMenu
 )
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, Signal, QTimer
 from PySide6.QtGui import QAction
 
 from gui.workers.download_queue import DownloadQueue
@@ -21,7 +21,7 @@ from spotify_api.token_manager import TokenManager
 class SpotifyView(QWidget):
     """View for Spotify playlist browsing and track selection."""
 
-    connection_changed = Signal(bool)
+    connection_changed = Signal(bool)  # Emits connection status
 
     def __init__(self, config: dict, queue: DownloadQueue, parent=None):
         super().__init__(parent)
@@ -29,6 +29,7 @@ class SpotifyView(QWidget):
         self.queue = queue
         self.worker = None
         self.current_tracks = []
+        self._tracks_cache = {}
         self._updating_checks = False
         self._setup_ui()
         self._check_connection()
@@ -45,6 +46,7 @@ class SpotifyView(QWidget):
         header_layout.addWidget(title)
         header_layout.addStretch()
 
+        # Connection status
         self.status_label = QLabel("Not connected")
         self.status_label.setObjectName("subtitle")
         header_layout.addWidget(self.status_label)
@@ -54,10 +56,12 @@ class SpotifyView(QWidget):
         header_layout.addWidget(self.connect_btn)
         layout.addLayout(header_layout)
 
+        # Progress bar for loading
         self.progress_bar = QProgressBar()
         self.progress_bar.hide()
         layout.addWidget(self.progress_bar)
 
+        # Main content splitter
         splitter = QSplitter(Qt.Horizontal)
 
         # Left panel - Playlists
@@ -69,6 +73,7 @@ class SpotifyView(QWidget):
         playlists_label.setObjectName("section")
         left_layout.addWidget(playlists_label)
 
+        # Refresh button
         btn_row = QHBoxLayout()
         self.refresh_btn = QPushButton("Refresh")
         self.refresh_btn.setObjectName("secondary")
@@ -85,11 +90,24 @@ class SpotifyView(QWidget):
         btn_row.addStretch()
         left_layout.addLayout(btn_row)
 
+        # Playlist list
         self.playlist_list = QListWidget()
-        self.playlist_list.itemClicked.connect(self._on_playlist_selected)
+        self.playlist_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.playlist_list.itemDoubleClicked.connect(self._on_playlist_selected)
         self.playlist_list.setContextMenuPolicy(Qt.CustomContextMenu)
         self.playlist_list.customContextMenuRequested.connect(self._show_playlist_context_menu)
         left_layout.addWidget(self.playlist_list)
+
+        bottom_row = QHBoxLayout()
+        self.load_selected_btn = QPushButton("Load")
+        self.load_selected_btn.setObjectName("secondary")
+        self.load_selected_btn.clicked.connect(self._load_selected_playlists)
+        bottom_row.addWidget(self.load_selected_btn)
+
+        self.download_selected_btn = QPushButton("Download")
+        self.download_selected_btn.clicked.connect(self._download_selected_playlists)
+        bottom_row.addWidget(self.download_selected_btn)
+        left_layout.addLayout(bottom_row)
 
         splitter.addWidget(left_panel)
 
@@ -98,17 +116,20 @@ class SpotifyView(QWidget):
         right_layout = QVBoxLayout(right_panel)
         right_layout.setContentsMargins(10, 0, 0, 0)
 
+        # Tracks header
         tracks_header = QHBoxLayout()
         self.tracks_label = QLabel("Tracks")
         self.tracks_label.setObjectName("section")
         tracks_header.addWidget(self.tracks_label)
         tracks_header.addStretch()
 
+        # Select all checkbox
         self.select_all_check = QCheckBox("Select All")
         self.select_all_check.stateChanged.connect(self._toggle_select_all)
         tracks_header.addWidget(self.select_all_check)
         right_layout.addLayout(tracks_header)
 
+        # Tracks table
         self.tracks_table = QTableWidget()
         self.tracks_table.setColumnCount(4)
         self.tracks_table.setHorizontalHeaderLabels(["", "Artist", "Track", "Album"])
@@ -127,6 +148,7 @@ class SpotifyView(QWidget):
         self.tracks_table.customContextMenuRequested.connect(self._show_context_menu)
         right_layout.addWidget(self.tracks_table)
 
+        # Add to queue button
         footer = QHBoxLayout()
         footer.addStretch()
         self.track_count_label = QLabel("0 tracks selected")
@@ -138,6 +160,8 @@ class SpotifyView(QWidget):
         right_layout.addLayout(footer)
 
         splitter.addWidget(right_panel)
+
+        # Set splitter proportions
         splitter.setSizes([300, 700])
         layout.addWidget(splitter, 1)
 
@@ -145,6 +169,7 @@ class SpotifyView(QWidget):
         auth = SpotifyPKCEAuth(self.config)
         token = auth.load_cached_token()
         if token and token.access_token:
+            # Check if expired
             if TokenManager.is_expired(token):
                 if token.refresh_token:
                     try:
@@ -167,6 +192,7 @@ class SpotifyView(QWidget):
             self.refresh_btn.setEnabled(True)
             self.liked_btn.setEnabled(True)
             self.connection_changed.emit(True)
+            # Auto-refresh playlists
             self._refresh_playlists()
         else:
             self.status_label.setText("Not connected")
@@ -196,9 +222,16 @@ class SpotifyView(QWidget):
         if reply == QMessageBox.Yes:
             self._show_oauth_dialog()
 
-    def _refresh_playlists(self):
+    def _stop_worker(self):
+        """Cancel any running worker before starting a new one."""
         if self.worker and self.worker.isRunning():
-            return
+            self.worker.cancel()
+            if not self.worker.wait(2000):
+                self.worker.terminate()
+
+    def _refresh_playlists(self):
+        self._stop_worker()
+        self._tracks_cache.clear()
         self.worker = SpotifyWorker(self.config)
         self.worker.playlists_loaded.connect(self._on_playlists_loaded)
         self.worker.error.connect(self._on_error)
@@ -220,6 +253,100 @@ class SpotifyView(QWidget):
             item.setData(Qt.UserRole, playlist)
             self.playlist_list.addItem(item)
 
+    def _load_selected_playlists(self):
+        """Queue all selected playlists for loading."""
+        selected = self.playlist_list.selectedItems()
+        if not selected:
+            QMessageBox.information(self, "No Selection", "Select playlists first (cmd+click for multiple).")
+            return
+        self._load_queue = []
+        for item in selected:
+            playlist = item.data(Qt.UserRole)
+            if playlist and playlist.get("id") and playlist["id"] not in self._tracks_cache:
+                self._load_queue.append((item, playlist))
+        if self._load_queue:
+            self._load_next_playlist()
+        else:
+            QMessageBox.information(self, "Already Loaded", "All selected playlists are already loaded.")
+
+    def _load_next_playlist(self):
+        if not self._load_queue:
+            return
+        if self.worker and self.worker.isRunning():
+            return
+        item, playlist = self._load_queue.pop(0)
+        self._on_playlist_selected(item)
+
+    def _download_selected_playlists(self):
+        """Queue all selected playlists for download. Uses cache if available, fetches if not."""
+        selected = self.playlist_list.selectedItems()
+        if not selected:
+            QMessageBox.information(self, "No Selection", "Select playlists first (cmd+click for multiple).")
+            return
+
+        queued_count = 0
+        self._download_queue_playlists = []
+        for item in selected:
+            playlist = item.data(Qt.UserRole)
+            if not playlist or not playlist.get("id"):
+                continue
+            pid = playlist["id"]
+            if pid in self._tracks_cache:
+                self.queue.add_tracks(self._tracks_cache[pid], playlist=playlist.get("name", ""))
+                queued_count += len(self._tracks_cache[pid])
+            else:
+                self._download_queue_playlists.append(playlist)
+
+        if self._download_queue_playlists:
+            self._fetch_and_queue_next()
+
+        if queued_count > 0:
+            msg = f"Added {queued_count} cached tracks to download queue."
+            if self._download_queue_playlists:
+                msg += f"\nFetching {len(self._download_queue_playlists)} more playlist(s)..."
+            QMessageBox.information(self, "Added to Queue", msg)
+
+    def _fetch_and_queue_next(self):
+        if not self._download_queue_playlists:
+            QMessageBox.information(self, "Done", "All selected playlists have been queued for download.")
+            return
+        self._stop_worker()
+        playlist = self._download_queue_playlists.pop(0)
+        self.worker = SpotifyWorker(self.config)
+        self.worker.tracks_loaded.connect(self._on_download_tracks_loaded)
+        self.worker.error.connect(self._on_error)
+        self.worker.progress.connect(self._on_progress)
+        self.worker.fetch_playlist_tracks(playlist["id"], playlist["name"])
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.show()
+
+    def _on_download_tracks_loaded(self, playlist_id: str, tracks: list):
+        self.progress_bar.hide()
+        self._tracks_cache[playlist_id] = tracks
+        self._update_playlist_track_count(playlist_id, len(tracks))
+        name = playlist_id
+        for i in range(self.playlist_list.count()):
+            item = self.playlist_list.item(i)
+            p = item.data(Qt.UserRole)
+            if p and p.get("id") == playlist_id:
+                name = p.get("name", playlist_id)
+                break
+        self.queue.add_tracks(tracks, playlist=name)
+        QTimer.singleShot(500, self._fetch_and_queue_next)
+
+    def _download_single_playlist(self, playlist: dict):
+        """Download a single playlist — use cache if available, fetch otherwise."""
+        pid = playlist.get("id")
+        name = playlist.get("name", "Unknown")
+        if pid in self._tracks_cache:
+            tracks = self._tracks_cache[pid]
+            self.queue.add_tracks(tracks, playlist=name)
+            QMessageBox.information(self, "Added to Queue",
+                f"Added {len(tracks)} tracks from \"{name}\" to download queue.")
+        else:
+            self._download_queue_playlists = [playlist]
+            self._fetch_and_queue_next()
+
     def _update_playlist_track_count(self, playlist_id: str, count: int):
         for i in range(self.playlist_list.count()):
             item = self.playlist_list.item(i)
@@ -234,21 +361,37 @@ class SpotifyView(QWidget):
         playlist = item.data(Qt.UserRole)
         if not playlist:
             return
-        if self.worker and self.worker.isRunning():
+        pid = playlist["id"]
+        self.tracks_label.setText(f"Tracks - {playlist['name']}")
+
+        if pid in self._tracks_cache:
+            self._populate_tracks(self._tracks_cache[pid])
             return
+
+        self._stop_worker()
         self.worker = SpotifyWorker(self.config)
+        self.worker.tracks_batch.connect(self._on_tracks_batch)
         self.worker.tracks_loaded.connect(self._on_tracks_loaded)
         self.worker.error.connect(self._on_error)
         self.worker.progress.connect(self._on_progress)
-        self.worker.fetch_playlist_tracks(playlist["id"], playlist["name"])
+        self.worker.fetch_playlist_tracks(pid, playlist["name"])
         self.progress_bar.setRange(0, 0)
         self.progress_bar.show()
-        self.tracks_label.setText(f"Tracks - {playlist['name']}")
+        self.current_tracks = []
+        self.tracks_table.blockSignals(True)
+        self.tracks_table.setRowCount(0)
+        self.tracks_table.blockSignals(False)
 
     def _fetch_liked_songs(self):
-        if self.worker and self.worker.isRunning():
+        self.tracks_label.setText("Tracks - Liked Songs")
+
+        if "__liked_songs__" in self._tracks_cache:
+            self._populate_tracks(self._tracks_cache["__liked_songs__"])
             return
+
+        self._stop_worker()
         self.worker = SpotifyWorker(self.config)
+        self.worker.tracks_batch.connect(self._on_tracks_batch)
         self.worker.liked_songs_loaded.connect(self._on_liked_songs_loaded)
         self.worker.error.connect(self._on_error)
         self.worker.progress.connect(self._on_progress)
@@ -256,16 +399,48 @@ class SpotifyView(QWidget):
         self.progress_bar.setRange(0, 0)
         self.progress_bar.show()
         self.liked_btn.setEnabled(False)
+        self.current_tracks = []
+        self.tracks_table.blockSignals(True)
+        self.tracks_table.setRowCount(0)
+        self.tracks_table.blockSignals(False)
+
+    def _on_tracks_batch(self, playlist_id: str, batch: list):
+        """Append a batch of tracks to the table as they stream in."""
+        self.tracks_table.blockSignals(True)
+        for track in batch:
+            self.current_tracks.append(track)
+            row = self.tracks_table.rowCount()
+            self.tracks_table.insertRow(row)
+            check_item = QTableWidgetItem()
+            check_item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+            check_item.setCheckState(Qt.CheckState.Unchecked)
+            self.tracks_table.setItem(row, 0, check_item)
+            self.tracks_table.setItem(row, 1, QTableWidgetItem(track.get("artist", "")))
+            self.tracks_table.setItem(row, 2, QTableWidgetItem(track.get("track", "")))
+            self.tracks_table.setItem(row, 3, QTableWidgetItem(track.get("album", "")))
+        self.tracks_table.blockSignals(False)
+        try:
+            self.tracks_table.selectionModel().selectionChanged.disconnect(self._on_selection_changed)
+        except RuntimeError:
+            pass
+        self.tracks_table.selectionModel().selectionChanged.connect(self._on_selection_changed)
+        self._update_selection_count()
+        self.add_btn.setEnabled(True)
 
     def _on_liked_songs_loaded(self, tracks: list):
         self.progress_bar.hide()
         self.liked_btn.setEnabled(True)
-        self.tracks_label.setText("Tracks - Liked Songs")
-        self._populate_tracks(tracks)
+        self._tracks_cache["__liked_songs__"] = tracks
+        self.tracks_table.selectionModel().selectionChanged.connect(self._on_selection_changed)
+        self._update_selection_count()
 
     def _on_tracks_loaded(self, playlist_id: str, tracks: list):
         self.progress_bar.hide()
-        self._populate_tracks(tracks)
+        self._tracks_cache[playlist_id] = tracks
+        self.tracks_table.selectionModel().selectionChanged.connect(self._on_selection_changed)
+        self._update_selection_count()
+        if hasattr(self, '_load_queue') and self._load_queue:
+            QTimer.singleShot(500, self._load_next_playlist)
         self._update_playlist_track_count(playlist_id, len(tracks))
 
     def _populate_tracks(self, tracks: list):
@@ -279,10 +454,13 @@ class SpotifyView(QWidget):
         for track in tracks:
             row = self.tracks_table.rowCount()
             self.tracks_table.insertRow(row)
+            # Checkbox
             check_item = QTableWidgetItem()
             check_item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
             check_item.setCheckState(Qt.CheckState.Unchecked)
             self.tracks_table.setItem(row, 0, check_item)
+
+            # Track data
             self.tracks_table.setItem(row, 1, QTableWidgetItem(track.get("artist", "")))
             self.tracks_table.setItem(row, 2, QTableWidgetItem(track.get("track", "")))
             self.tracks_table.setItem(row, 3, QTableWidgetItem(track.get("album", "")))
@@ -386,6 +564,15 @@ class SpotifyView(QWidget):
         if self.playlist_list.count() == 0:
             return
         menu = QMenu(self)
+        selected = self.playlist_list.selectedItems()
+        if len(selected) > 1:
+            load_sel = QAction(f"Load {len(selected)} Playlists", self)
+            load_sel.triggered.connect(self._load_selected_playlists)
+            menu.addAction(load_sel)
+            dl_sel = QAction(f"Download {len(selected)} Playlists", self)
+            dl_sel.triggered.connect(self._download_selected_playlists)
+            menu.addAction(dl_sel)
+            menu.addSeparator()
         item = self.playlist_list.itemAt(position)
         if item:
             playlist = item.data(Qt.UserRole)
@@ -393,6 +580,14 @@ class SpotifyView(QWidget):
                 load = QAction(f"Load \"{playlist.get('name', '')}\"", self)
                 load.triggered.connect(lambda checked, i=item: self._on_playlist_selected(i))
                 menu.addAction(load)
+
+                dl = QAction(f"Download \"{playlist.get('name', '')}\"", self)
+                dl.triggered.connect(lambda checked, p=playlist: self._download_single_playlist(p))
+                menu.addAction(dl)
+        menu.addSeparator()
+        sa = QAction("Select All Playlists", self)
+        sa.triggered.connect(self.playlist_list.selectAll)
+        menu.addAction(sa)
         menu.exec(self.playlist_list.viewport().mapToGlobal(position))
 
     def _set_all_checked(self, checked: bool):
@@ -432,7 +627,10 @@ class SpotifyView(QWidget):
         if not tracks:
             QMessageBox.information(self, "No Selection", "Please select tracks to download.")
             return
+        # Get playlist name for the queue
         playlist_name = self.tracks_label.text().replace("Tracks - ", "")
+
+        # Add to queue
         self.queue.add_tracks(tracks, playlist=playlist_name)
         QMessageBox.information(
             self, "Added to Queue",

--- a/gui/views/welcome_view.py
+++ b/gui/views/welcome_view.py
@@ -105,6 +105,7 @@ class StepCard(QFrame):
     def __init__(self, number: int, title: str, description: str, parent=None):
         super().__init__(parent)
         self.setObjectName("card")
+        self.setStyleSheet("StepCard { background-color: #282840; }")
         self._setup_ui(number, title, description)
 
     def _setup_ui(self, number: int, title: str, description: str):
@@ -253,7 +254,19 @@ class WelcomeView(QWidget):
         """)
         easiest_header.addWidget(easiest_badge)
 
+        self.toggle_help_btn = QPushButton("Hide Guide")
+        self.toggle_help_btn.setObjectName("ghost")
+        self.toggle_help_btn.clicked.connect(self._toggle_help)
+        easiest_header.addWidget(self.toggle_help_btn)
+
         easiest_layout.addLayout(easiest_header)
+
+        # Collapsible help content
+        self.help_container = QWidget()
+        self.help_container.setStyleSheet("background: transparent;")
+        help_layout = QVBoxLayout(self.help_container)
+        help_layout.setContentsMargins(0, 0, 0, 0)
+        help_layout.setSpacing(12)
 
         # Explanation
         explanation = QLabel(
@@ -262,7 +275,7 @@ class WelcomeView(QWidget):
         )
         explanation.setStyleSheet("font-size: 14px; line-height: 1.5;")
         explanation.setWordWrap(True)
-        easiest_layout.addWidget(explanation)
+        help_layout.addWidget(explanation)
 
         # Steps
         steps_layout = QVBoxLayout()
@@ -296,14 +309,31 @@ class WelcomeView(QWidget):
         )
         steps_layout.addWidget(step4)
 
-        easiest_layout.addLayout(steps_layout)
+        help_layout.addLayout(steps_layout)
+        easiest_layout.addWidget(self.help_container)
 
         # Link to exportify
         link_layout = QHBoxLayout()
         link_layout.setSpacing(12)
 
-        exportify_btn = QPushButton("Open exportify.net")
-        exportify_btn.setObjectName("secondary")
+        exportify_btn = QPushButton("\u2197  Open exportify.net")
+        exportify_btn.setStyleSheet("""
+            QPushButton {
+                background-color: rgba(255, 255, 255, 0.12);
+                color: #e3e4e0;
+                border: 1px solid rgba(255, 255, 255, 0.2);
+                padding: 10px 20px;
+                border-radius: 6px;
+                font-weight: 600;
+                font-size: 13px;
+            }
+            QPushButton:hover {
+                background-color: rgba(255, 255, 255, 0.2);
+                border-color: rgba(255, 255, 255, 0.35);
+            }
+            QPushButton:pressed { background-color: rgba(255, 255, 255, 0.08); }
+        """)
+        exportify_btn.setCursor(Qt.PointingHandCursor)
         exportify_btn.clicked.connect(self._open_exportify)
         link_layout.addWidget(exportify_btn)
 
@@ -436,6 +466,11 @@ class WelcomeView(QWidget):
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.addWidget(scroll)
+
+    def _toggle_help(self):
+        visible = self.help_container.isVisible()
+        self.help_container.setVisible(not visible)
+        self.toggle_help_btn.setText("Show Guide" if visible else "Hide Guide")
 
     def _open_exportify(self):
         """Open Exportify website in browser."""

--- a/gui/workers/spotify_worker.py
+++ b/gui/workers/spotify_worker.py
@@ -143,7 +143,7 @@ class SpotifyWorker(QThread):
             items = result.get("items", [])
 
             for item in items:
-                track_obj = item.get("track")
+                track_obj = item.get("item") or item.get("track")
                 if not track_obj:
                     continue
 

--- a/gui/workers/spotify_worker.py
+++ b/gui/workers/spotify_worker.py
@@ -22,6 +22,7 @@ class SpotifyWorker(QThread):
 
     playlists_loaded = Signal(list)  # List of playlist dicts
     tracks_loaded = Signal(str, list)  # playlist_id, list of track dicts
+    tracks_batch = Signal(str, list)  # playlist_id, batch of tracks (streaming)
     liked_songs_loaded = Signal(list)  # List of track dicts
     error = Signal(str)  # Error message
     progress = Signal(str, int, int)  # message, current, total
@@ -142,6 +143,7 @@ class SpotifyWorker(QThread):
             result = client.playlist_items(playlist_id, limit=limit, offset=offset)
             items = result.get("items", [])
 
+            batch = []
             for item in items:
                 track_obj = item.get("item") or item.get("track")
                 if not track_obj:
@@ -160,6 +162,10 @@ class SpotifyWorker(QThread):
                     "spotify_id": track_obj.get("id"),
                 }
                 tracks.append(track)
+                batch.append(track)
+
+            if batch and not self._cancelled:
+                self.tracks_batch.emit(playlist_id, batch)
 
             total = result.get("total", 0)
             self.progress.emit(
@@ -188,6 +194,7 @@ class SpotifyWorker(QThread):
             result = client.current_user_saved_tracks(limit=limit, offset=offset)
             items = result.get("items", [])
 
+            batch = []
             for item in items:
                 track_obj = item.get("track")
                 if not track_obj:
@@ -206,6 +213,10 @@ class SpotifyWorker(QThread):
                     "spotify_id": track_obj.get("id"),
                 }
                 tracks.append(track)
+                batch.append(track)
+
+            if batch and not self._cancelled:
+                self.tracks_batch.emit("__liked_songs__", batch)
 
             total = result.get("total", 0)
             self.progress.emit(f"Loaded {len(tracks)} of {total} liked songs", len(tracks), total)

--- a/spotify_api/client.py
+++ b/spotify_api/client.py
@@ -237,7 +237,7 @@ class SpotifyClient:
     def playlist_items(self, playlist_id: str, *, limit: int = 100, offset: int = 0) -> Dict[str, Any]:
         return self.request_json(
             "GET",
-            f"/playlists/{playlist_id}/tracks",
+            f"/playlists/{playlist_id}/items",
             params={"limit": limit, "offset": offset, "additional_types": "track"},
         )
 
@@ -254,7 +254,7 @@ class SpotifyClient:
     def get_playlist_tracks(self, playlist_id: str, *, limit: int = 100) -> List[Dict[str, Any]]:
         # Endpoint shape: {items: [{added_at, track: {...}}], total, ...}
         return self._paginate(
-            f"/playlists/{playlist_id}/tracks",
+            f"/playlists/{playlist_id}/items",
             params={"limit": min(100, int(limit)), "additional_types": "track"},
             page_key="items",
         )

--- a/spotify_api/data_loader.py
+++ b/spotify_api/data_loader.py
@@ -86,7 +86,7 @@ class SpotifyDataLoader:
             for item in items:
                 if not isinstance(item, dict):
                     continue
-                track_obj = item.get("track")
+                track_obj = item.get("item") or item.get("track")
                 normalized = self._normalize_track(track_obj)
                 if normalized:
                     # preserve playlist-added timestamp if available
@@ -138,7 +138,7 @@ class SpotifyDataLoader:
             for item in items:
                 if not isinstance(item, dict):
                     continue
-                track_obj = item.get("track")
+                track_obj = item.get("item") or item.get("track")
                 normalized = self._normalize_track(track_obj)
                 if normalized:
                     if item.get("added_at"):

--- a/spotify_api/token_manager.py
+++ b/spotify_api/token_manager.py
@@ -5,7 +5,19 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 
-DEFAULT_TOKEN_CACHE_PATH = os.path.join("data", "spotify_tokens.json")
+def _get_default_cache_path():
+    """Resolve token cache path relative to the app directory, not the working directory."""
+    try:
+        import sys
+        if getattr(sys, 'frozen', False):
+            base = os.path.dirname(sys.executable)
+        else:
+            base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    except Exception:
+        base = "."
+    return os.path.join(base, "data", "spotify_tokens.json")
+
+DEFAULT_TOKEN_CACHE_PATH = _get_default_cache_path()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This PR resolves #22  and #24 

Track selection was not working as expected. Select All, cmd+click, shift+click, and drag-select didn't work as expected. Additionally, all playlist track loading returned 403 Forbidden due to Spotify having deprecated their `/playlists/{id}/tracks` endpoint in February 2026.

This includes some additional changes I've made on my end for QOL + how strict Spotify has gotten with API usage (caching/loading improvements + easier ways to get to actions)

I have tested the below on MacOS + WIndows

## What this  PR Changes

### Spotify API compatibility
- Migrate from removed `/playlists/{id}/tracks` to `/playlists/{id}/items`
- Handle both old (`"track"`) and new (`"item"`) response keys for backward compatibility

### Track selection
- Replace embedded `QCheckBox` widgets with native `QTableWidgetItem` check states
- Fix PySide6 `stateChanged` signal sending `int` instead of `Qt.CheckState` enum, which caused `Select All` to silently fail on every comparison
- Sync table row selection to checkbox state via `selectionChanged` signal
- Connect `itemChanged` once in setup instead of per-populate to prevent duplicate handlers

### Streaming track loading
- Tracks appear in the table page-by-page as the API responds instead of waiting for the full playlist
- In-memory cache prevents redundant API calls when switching between already-loaded playlists
- 500ms delay between sequential batch fetches to avoid Spotify rate limiting

### Playlist management
- Load and Download actions in the playlist right-click context menu
- Multi-select playlists with cmd+click for batch load/download operations
- Playlist track counts update after successful load

### Additional fixes
- `selection-background-color` on `QTableWidget` prevents macOS system accent from bleeding through
- Cross-platform font stack (`Helvetica Neue`, `Segoe UI`, `Arial`)
- Settings save uses safe int parsing instead of bare `int()` which aborted the entire save on invalid input
- All views share the same config reference after settings save
- Collapsible exportify guide on the welcome page
- Import CSV and Exportify shortcut buttons in the status bar
- Auto-reconnect prompt on 401/expired token errors
- Fix issue where DEFAULT_TOKEN_CACHE_PATH used a relative path (data/spotify_tokens.json). In a release build, the working directory isn't the app directory, so the token file was written/read from the wrong location. Now it resolves to an absolute path using the same logic as config.py.

## Screenshots
### Individual select
<img width="2400" height="1600" alt="pr-05-dragselect" src="https://github.com/user-attachments/assets/84575fdd-db3d-4606-98cd-8e2478ae1999" />

### Select all checked
<img width="2400" height="1600" alt="pr-04-selectall" src="https://github.com/user-attachments/assets/e27d718d-0971-488b-903a-bed38b358ec7" />

### Context menu for playlists (spotify)
<img width="323" height="227" alt="image" src="https://github.com/user-attachments/assets/81061123-ac13-4d7d-9587-34a708bd9a9e" />

### Context menu for song selection spotify)
<img width="328" height="224" alt="image" src="https://github.com/user-attachments/assets/19868146-dcf8-4fc1-83af-8fe445d4f108" />

### Status bar quick actions 
<img width="926" height="100" alt="image" src="https://github.com/user-attachments/assets/5f45a245-a573-4371-b57c-f95d0ae22e0d" />

### Collapsed welcome guide section
<img width="982" height="505" alt="image" src="https://github.com/user-attachments/assets/4a7d193a-e3fc-4ce7-a800-95177ca48fe9" />

### Welcome guide section (default)
<img width="1138" height="625" alt="image" src="https://github.com/user-attachments/assets/b074fd39-9b60-4503-aa65-08008c7f3bfe" />


## Verification Steps

- [ ] Connect to Spotify, verify playlists load
- [ ] Click a playlist, verify tracks stream in progressively
- [ ] Select All checkbox selects all rows with correct count
- [ ] Cmd+click, shift+click, and drag-select sync to checkboxes
- [ ] Right-click a playlist , Load and Download actions work
- [ ] Multi-select playlists, batch load/download
- [ ] Switch between loaded playlists , this should be instant from cache
- [ ] Click Refresh, this clears cache, reloads from API
- [ ] Open Settings, clear a numeric field, saving should not crash
- [ ] Toggle Hide Guide / Show Guide on welcome page
- [ ] Click Import CSV and Exportify in the status bar